### PR TITLE
Pomodoro: forced redrawing

### DIFF
--- a/apps_source_code/pomodoro/pomodoro.c
+++ b/apps_source_code/pomodoro/pomodoro.c
@@ -9,6 +9,26 @@ enum PomodoroDebugSubmenuIndex {
     PomodoroSubmenuIndex50,
 };
 
+static void pomodoro_view_dispatcher_update_callback(void* context) {
+    furi_assert(context);
+    Pomodoro* app = (Pomodoro*)context;
+    switch(app->view_id) {
+    case PomodoroView10:
+        pomodoro_timer_update(app->pomodoro_10);
+        break;
+    case PomodoroView25:
+        pomodoro_timer_update(app->pomodoro_25);
+        break;
+    case PomodoroView50:
+        pomodoro_timer_update(app->pomodoro_50);
+        break;
+
+    default:
+        break;
+    }
+    pomodoro_timer_update(app->pomodoro_25);
+}
+
 void pomodoro_submenu_callback(void* context, uint32_t index) {
     furi_assert(context);
     Pomodoro* app = context;
@@ -59,6 +79,9 @@ Pomodoro* pomodoro_app_alloc() {
 
     // View dispatcher
     app->view_dispatcher = view_dispatcher_alloc();
+    view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
+    view_dispatcher_set_tick_event_callback(
+        app->view_dispatcher, pomodoro_view_dispatcher_update_callback, 1000);
     view_dispatcher_enable_queue(app->view_dispatcher);
     view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
 

--- a/apps_source_code/pomodoro/pomodoro_timer.c
+++ b/apps_source_code/pomodoro/pomodoro_timer.c
@@ -240,3 +240,8 @@ void pomodoro_draw_callback(Canvas* canvas, void* context, int max_seconds, int 
         canvas_draw_disc(canvas, 122 - i * 10, 15, 4);
     }
 }
+
+void pomodoro_timer_update(PomodoroTimer* pomodoro_timer) {
+    with_view_model(
+        pomodoro_timer->view, PomodoroTimerModel * model, { UNUSED(model); }, true);
+}

--- a/apps_source_code/pomodoro/pomodoro_timer.h
+++ b/apps_source_code/pomodoro/pomodoro_timer.h
@@ -31,3 +31,5 @@ struct PomodoroTimerModel {
 void pomodoro_timer_process(PomodoroTimer* pomodoro_timer, InputEvent* event);
 
 void pomodoro_draw_callback(Canvas* canvas, void* context, int max_seconds, int max_seconds_rest);
+
+void pomodoro_timer_update(PomodoroTimer* pomodoro_timer);


### PR DESCRIPTION
Fix `pomodoro_timer` drawing when it was launched from favorites