### PR TITLE
PTT: redesigned hotkeys to ignore any keys when PTT pressed

### DIFF
--- a/base_pack/hid_app/hid.c
+++ b/base_pack/hid_app/hid.c
@@ -83,26 +83,9 @@ static void bt_hid_connection_status_changed_callback(BtStatus status, void* con
     hid_tikshorts_set_connected_status(hid->hid_tikshorts, connected);
 }
 
-static void hid_dialog_callback(DialogExResult result, void* context) {
-    furi_assert(context);
-    Hid* app = context;
-    if(result == DialogExResultLeft) {
-        view_dispatcher_stop(app->view_dispatcher);
-    } else if(result == DialogExResultRight) {
-        view_dispatcher_switch_to_view(app->view_dispatcher, app->view_id); // Show last view
-    } else if(result == DialogExResultCenter) {
-        view_dispatcher_switch_to_view(app->view_dispatcher, HidViewSubmenu);
-    }
-}
-
 static uint32_t hid_menu_view(void* context) {
     UNUSED(context);
     return HidViewSubmenu;
-}
-
-static uint32_t hid_exit_confirm_view(void* context) {
-    UNUSED(context);
-    return HidViewExitConfirm;
 }
 
 static uint32_t hid_exit(void* context) {
@@ -180,16 +163,6 @@ Hid* hid_alloc(HidTransport transport) {
 Hid* hid_app_alloc_view(void* context) {
     furi_assert(context);
     Hid* app = context;
-    // Dialog view
-    app->dialog = dialog_ex_alloc();
-    dialog_ex_set_result_callback(app->dialog, hid_dialog_callback);
-    dialog_ex_set_context(app->dialog, app);
-    dialog_ex_set_left_button_text(app->dialog, "Exit");
-    dialog_ex_set_right_button_text(app->dialog, "Stay");
-    dialog_ex_set_center_button_text(app->dialog, "Menu");
-    dialog_ex_set_header(app->dialog, "Close Current App?", 16, 12, AlignLeft, AlignTop);
-    view_dispatcher_add_view(
-        app->view_dispatcher, HidViewExitConfirm, dialog_ex_get_view(app->dialog));
 
     // Keynote view
     app->hid_keynote = hid_keynote_alloc(app);
@@ -223,13 +196,13 @@ Hid* hid_app_alloc_view(void* context) {
 
     // TikTok / YT Shorts view
     app->hid_tikshorts = hid_tikshorts_alloc(app);
-    view_set_previous_callback(hid_tikshorts_get_view(app->hid_tikshorts), hid_exit_confirm_view);
+    view_set_previous_callback(hid_tikshorts_get_view(app->hid_tikshorts), hid_menu_view);
     view_dispatcher_add_view(
         app->view_dispatcher, BtHidViewTikShorts, hid_tikshorts_get_view(app->hid_tikshorts));
 
     // Mouse view
     app->hid_mouse = hid_mouse_alloc(app);
-    view_set_previous_callback(hid_mouse_get_view(app->hid_mouse), hid_exit_confirm_view);
+    view_set_previous_callback(hid_mouse_get_view(app->hid_mouse), hid_menu_view);
     view_dispatcher_add_view(
         app->view_dispatcher, HidViewMouse, hid_mouse_get_view(app->hid_mouse));
 
@@ -271,8 +244,6 @@ void hid_free(Hid* app) {
     // Free views
     view_dispatcher_remove_view(app->view_dispatcher, HidViewSubmenu);
     submenu_free(app->device_type_submenu);
-    view_dispatcher_remove_view(app->view_dispatcher, HidViewExitConfirm);
-    dialog_ex_free(app->dialog);
     view_dispatcher_remove_view(app->view_dispatcher, HidViewKeynote);
     hid_keynote_free(app->hid_keynote);
     view_dispatcher_remove_view(app->view_dispatcher, HidViewKeyboard);

--- a/base_pack/hid_app/hid.h
+++ b/base_pack/hid_app/hid.h
@@ -22,8 +22,8 @@
 #include "views/hid_media.h"
 #include "views/hid_movie.h"
 #include "views/hid_mouse.h"
-#include "views/hid_mouse_jiggler.h"
 #include "views/hid_mouse_clicker.h"
+#include "views/hid_mouse_jiggler.h"
 #include "views/hid_tikshorts.h"
 #include "views/hid_ptt.h"
 

--- a/base_pack/hid_app/views.h
+++ b/base_pack/hid_app/views.h
@@ -10,5 +10,4 @@ typedef enum {
     HidViewMouseJiggler,
     BtHidViewTikShorts,
     HidViewPtt,
-    HidViewExitConfirm,
 } HidView;

--- a/base_pack/hid_app/views/hid_media.c
+++ b/base_pack/hid_app/views/hid_media.c
@@ -188,12 +188,15 @@ static bool hid_media_input_callback(InputEvent* event, void* context) {
     HidMedia* hid_media = context;
     bool consumed = false;
 
-    if(event->type == InputTypePress) {
-        hid_media_process_press(hid_media, event);
+    if(event->type == InputTypeLong && event->key == InputKeyBack) {
+        hid_hal_keyboard_release_all(hid_media->hid);
+    } else {
         consumed = true;
-    } else if(event->type == InputTypeRelease) {
-        hid_media_process_release(hid_media, event);
-        consumed = true;
+        if(event->type == InputTypePress) {
+            hid_media_process_press(hid_media, event);
+        } else if(event->type == InputTypeRelease) {
+            hid_media_process_release(hid_media, event);
+        }
     }
     return consumed;
 }

--- a/base_pack/hid_app/views/hid_movie.c
+++ b/base_pack/hid_app/views/hid_movie.c
@@ -186,13 +186,19 @@ static bool hid_movie_input_callback(InputEvent* event, void* context) {
     HidMovie* hid_movie = context;
     bool consumed = false;
 
-    if(event->type == InputTypePress) {
-        hid_movie_process_press(hid_movie, event);
+    if(event->type == InputTypeLong && event->key == InputKeyBack) {
+        hid_hal_keyboard_release_all(hid_movie->hid);
+    } else {
         consumed = true;
-    } else if(event->type == InputTypeRelease) {
-        hid_movie_process_release(hid_movie, event);
-        consumed = true;
+        if(event->type == InputTypePress) {
+            hid_movie_process_press(hid_movie, event);
+            consumed = true;
+        } else if(event->type == InputTypeRelease) {
+            hid_movie_process_release(hid_movie, event);
+            consumed = true;
+        }
     }
+
     return consumed;
 }
 

--- a/base_pack/hid_app/views/hid_ptt.c
+++ b/base_pack/hid_app/views/hid_ptt.c
@@ -21,6 +21,7 @@ typedef struct {
     bool muted;
     bool ptt_pressed;
     bool mic_pressed;
+    bool mic_sync_pressed;
     bool connected;
     bool is_mac_os;
     uint32_t appIndex;
@@ -81,8 +82,9 @@ static void hid_ptt_draw_callback(Canvas* canvas, void* context) {
 
     // Mic label
     const uint8_t y_mic = 102;
-    canvas_draw_icon(canvas, 19, y_mic - 1, &I_Pin_back_arrow_rotated_8x10);
-    elements_multiline_text_aligned(canvas, 0, y_mic, AlignLeft, AlignTop, "Hold      to sync");
+    canvas_draw_icon(canvas, 0, y_mic - 1, &I_Pin_back_arrow_rotated_8x10);
+    canvas_draw_icon(canvas, 18, y_mic - 1, &I_Ok_btn_9x9);
+    elements_multiline_text_aligned(canvas, 11, y_mic, AlignLeft, AlignTop, "+      to sync");
     elements_multiline_text_aligned(canvas, 20, y_mic+10, AlignLeft, AlignTop, "mic status");
 
     // Exit label
@@ -96,71 +98,73 @@ static void hid_ptt_draw_callback(Canvas* canvas, void* context) {
     const uint8_t y_1 = 19;
     const uint8_t y_2 = y_1 + 19;
     const uint8_t y_3 = y_2 + 19;
-
-    // Up
-    canvas_draw_icon(canvas, x_2, y_1, &I_Button_18x18);
-    if(model->up_pressed) {
-        elements_slightly_rounded_box(canvas, x_2 + 3, y_1 + 2, 13, 13);
-        canvas_set_color(canvas, ColorWhite);
-    }
-    if(model->ptt_pressed) {
-        if (model->appIndex != HidPttAppIndexFaceTime) {
-            elements_multiline_text_aligned(canvas, x_2 + 4, y_1 + 5, AlignLeft, AlignTop, "OS");
+    if(!model->ptt_pressed || model->mic_pressed || model->up_pressed || model->down_pressed || model->left_pressed || model->right_pressed || model->mic_sync_pressed) {
+        // Up
+        canvas_draw_icon(canvas, x_2, y_1, &I_Button_18x18);
+        if(model->up_pressed) {
+            elements_slightly_rounded_box(canvas, x_2 + 3, y_1 + 2, 13, 13);
+            canvas_set_color(canvas, ColorWhite);
         }
-    } else {
-        canvas_draw_icon(canvas, x_2 + 5, y_1 + 5, &I_Volup_8x6);
-    }
-    canvas_set_color(canvas, ColorBlack);
-
-    // Down
-    canvas_draw_icon(canvas, x_2, y_3, &I_Button_18x18);
-    if(model->down_pressed) {
-        elements_slightly_rounded_box(canvas, x_2 + 3, y_3 + 2, 13, 13);
-        canvas_set_color(canvas, ColorWhite);
-    }
-    if(!model->ptt_pressed) {
-        canvas_draw_icon(canvas, x_2 + 6, y_3 + 5, &I_Voldwn_6x6);
-    }
-    canvas_set_color(canvas, ColorBlack);
-
-    // Left
-    canvas_draw_icon(canvas, x_1, y_2, &I_Button_18x18);
-    if(model->left_pressed) {                                             
-        elements_slightly_rounded_box(canvas, x_1 + 3, y_2 + 2, 13, 13);
-        canvas_set_color(canvas, ColorWhite);
-    }
-    if (model->ptt_pressed) {
-        canvas_draw_icon(canvas, x_1 + 7, y_2 + 5, &I_ButtonLeft_4x7);
-    } else {  
-        canvas_draw_icon(canvas, x_1 + 4, y_2 + 5, &I_Pin_back_arrow_10x8);
-    }
-    canvas_set_color(canvas, ColorBlack);
-
-    // Right / Camera
-    canvas_draw_icon(canvas, x_3, y_2, &I_Button_18x18);
-    if(model->right_pressed) {
-        elements_slightly_rounded_box(canvas, x_3 + 3, y_2 + 2, 13, 13);
-        canvas_set_color(canvas, ColorWhite);
-    }
-    if(!model->ptt_pressed) {
-        if (model->appIndex != HidPttAppIndexFaceTime) {
-            canvas_draw_icon(canvas, x_3 + 11, y_2 + 5, &I_ButtonLeft_4x7);
-            canvas_draw_box(canvas, x_3 + 4, y_2 + 5, 7, 7);
+        if(model->mic_pressed) {
+            if (model->appIndex != HidPttAppIndexFaceTime) {
+                elements_multiline_text_aligned(canvas, x_2 + 4, y_1 + 5, AlignLeft, AlignTop, "OS");
+            }
+        } else {
+            canvas_draw_icon(canvas, x_2 + 5, y_1 + 5, &I_Volup_8x6);
         }
-    } else {
-        canvas_draw_icon(canvas, x_3 + 8, y_2 + 5, &I_ButtonRight_4x7);
-    }
-    canvas_set_color(canvas, ColorBlack);
+        canvas_set_color(canvas, ColorBlack);
 
+        // Down
+        canvas_draw_icon(canvas, x_2, y_3, &I_Button_18x18);
+        if(model->down_pressed) {
+            elements_slightly_rounded_box(canvas, x_2 + 3, y_3 + 2, 13, 13);
+            canvas_set_color(canvas, ColorWhite);
+        }
+        if(!model->mic_pressed) {
+            canvas_draw_icon(canvas, x_2 + 6, y_3 + 5, &I_Voldwn_6x6);
+        }
+        canvas_set_color(canvas, ColorBlack);
+
+        // Left
+        canvas_draw_icon(canvas, x_1, y_2, &I_Button_18x18);
+        if(model->left_pressed) {                                             
+            elements_slightly_rounded_box(canvas, x_1 + 3, y_2 + 2, 13, 13);
+            canvas_set_color(canvas, ColorWhite);
+        }
+        if (model->mic_pressed) {
+            canvas_draw_icon(canvas, x_1 + 7, y_2 + 5, &I_ButtonLeft_4x7);
+        } else {  
+            canvas_draw_icon(canvas, x_1 + 4, y_2 + 5, &I_Pin_back_arrow_10x8);
+        }
+        canvas_set_color(canvas, ColorBlack);
+
+        // Right / Camera
+        canvas_draw_icon(canvas, x_3, y_2, &I_Button_18x18);
+        if(model->right_pressed) {
+            elements_slightly_rounded_box(canvas, x_3 + 3, y_2 + 2, 13, 13);
+            canvas_set_color(canvas, ColorWhite);
+        }
+        if(!model->mic_pressed) {
+            if (model->appIndex != HidPttAppIndexFaceTime) {
+                canvas_draw_icon(canvas, x_3 + 11, y_2 + 5, &I_ButtonLeft_4x7);
+                canvas_draw_box(canvas, x_3 + 4, y_2 + 5, 7, 7);
+            }
+        } else {
+            canvas_draw_icon(canvas, x_3 + 8, y_2 + 5, &I_ButtonRight_4x7);
+        }
+        canvas_set_color(canvas, ColorBlack);
+
+    }
     // Back / Mic
     const uint8_t x_mic = x_3;
     canvas_draw_icon(canvas, x_mic, 0, &I_Button_18x18);
     if(model->mic_pressed) {
-        elements_slightly_rounded_box(canvas, x_mic + 3, 0 + 2, 13, 13);
+        elements_slightly_rounded_box(canvas, x_mic + 3, 2, 13, 13);
         canvas_set_color(canvas, ColorWhite);
     }
-    canvas_draw_icon(canvas, x_mic + 5, 0 + 4, &I_Mic_btn_8x10);
-    if(model->muted && !model->ptt_pressed) {
+    canvas_draw_icon(canvas, x_mic + 5, 4, &I_Mic_btn_8x10);
+    
+    if (!(!model->muted || (model->ptt_pressed && !model->mic_sync_pressed))) {
         canvas_draw_line(canvas, x_mic + 3, 2     , x_mic + 3 + 13, 2 + 13);
         canvas_draw_line(canvas, x_mic + 2, 2     , x_mic + 2 + 13, 2 + 13);
         canvas_draw_line(canvas, x_mic + 3, 2 + 13, x_mic + 3 + 13, 2);
@@ -177,13 +181,33 @@ static void hid_ptt_draw_callback(Canvas* canvas, void* context) {
     canvas_draw_line(canvas, x_ptt + 3                             , y_2     , x_ptt + x_ptt_width + 2 + x_ptt_margin, y_2);
     canvas_draw_line(canvas, x_ptt + 3                             , y_2 + 16, x_ptt + x_ptt_width + 2 + x_ptt_margin, y_2 + 16);
     canvas_draw_line(canvas, x_ptt + 3                             , y_2 + 17, x_ptt + x_ptt_width + 2 + x_ptt_margin, y_2 + 17);
-    if(model->ptt_pressed) {
-        elements_slightly_rounded_box(canvas, x_ptt + 3, y_2 + 2, x_ptt_width + x_ptt_margin, 13);
+
+    if (!model->ptt_pressed && !model->muted && model->mic_pressed) {
+        elements_slightly_rounded_box(canvas, x_ptt + 3, y_2 + 2, (x_ptt_width + x_ptt_margin) / 2, 13);
         canvas_set_color(canvas, ColorWhite);
     }
-    canvas_set_font(canvas, FontPrimary);
-    elements_multiline_text_aligned(canvas, x_ptt + 2 + x_ptt_margin / 2, y_2 + 13, AlignLeft, AlignBottom, "PTT");
-    canvas_set_font(canvas, FontSecondary);
+    if (model->mic_pressed) {
+        canvas_draw_icon(canvas, x_ptt + 4, y_2 + 4, &I_Mic_btn_8x10);
+    }
+    canvas_set_color(canvas, ColorBlack);
+    if(!model->ptt_pressed && model->muted && model->mic_pressed) {
+        elements_slightly_rounded_box(canvas, x_ptt + 3 + (x_ptt_width + x_ptt_margin) / 2, y_2 + 2, (x_ptt_width + x_ptt_margin) / 2, 13);
+        canvas_set_color(canvas, ColorWhite);
+    }
+    if (model->mic_pressed) {
+        canvas_draw_icon(canvas, x_ptt + 14, y_2 + 4, &I_Mic_btn_8x10);
+        canvas_draw_line(canvas, x_ptt + 13, y_2 + 3 , x_ptt + 22, y_2 + 14);
+        canvas_draw_line(canvas, x_ptt + 13, y_2 + 14, x_ptt + 22, y_2 + 3);
+    } else {
+        if (model->ptt_pressed && !model->mic_sync_pressed) {
+            elements_slightly_rounded_box(canvas, x_ptt + 3, y_2 + 2, x_ptt_width + x_ptt_margin, 13);
+            canvas_set_color(canvas, ColorWhite);
+        }
+        canvas_set_font(canvas, FontPrimary);
+        elements_multiline_text_aligned(canvas, x_ptt + 2 + x_ptt_margin / 2, y_2 + 13, AlignLeft, AlignBottom, "PTT");
+        canvas_set_font(canvas, FontSecondary);
+    }
+    canvas_set_color(canvas, ColorBlack);
 }
 
 static void hid_ptt_trigger_mute(HidPtt* hid_ptt, HidPttModel * model) {
@@ -285,10 +309,10 @@ static void hid_ptt_process(HidPtt* hid_ptt, InputEvent* event) {
         hid_ptt->view,
         HidPttModel * model,
         {
-            if(event->type == InputTypePress) {
+            if(event->type == InputTypePress && !model->ptt_pressed) {
                 if(event->key == InputKeyUp) {
                     model->up_pressed = true;
-                    if (!model->ptt_pressed){
+                    if (!model->mic_pressed){
                         hid_hal_consumer_key_press(hid_ptt->hid, HID_CONSUMER_VOLUME_INCREMENT);
                     } else {
                         if (model->appIndex != HidPttAppIndexFaceTime) {
@@ -298,28 +322,35 @@ static void hid_ptt_process(HidPtt* hid_ptt, InputEvent* event) {
                     }
                 } else if(event->key == InputKeyDown) {
                     model->down_pressed = true;
-                    if (!model->ptt_pressed){
+                    if (!model->mic_pressed){
                         hid_hal_consumer_key_press(hid_ptt->hid, HID_CONSUMER_VOLUME_DECREMENT);
-                    } else {
+                    } else if (!model->mic_pressed) {
                         hid_ptt_shift_app(model, - 1);
                         notification_message(hid_ptt->hid->notifications, &sequence_single_vibro);
                     }
                 } else if(event->key == InputKeyLeft) {
                     model->left_pressed = true;
-                    if (model->ptt_pressed){
+                    if (model->mic_pressed){
                         hid_ptt_shift_app(model, 1);
                         notification_message(hid_ptt->hid->notifications, &sequence_single_vibro);
                     }
                 } else if(event->key == InputKeyRight) {
                     model->right_pressed = true;
-                    if (model->ptt_pressed){
+                    if (model->mic_pressed){
                         hid_ptt_shift_app(model, - 1);
                         notification_message(hid_ptt->hid->notifications, &sequence_single_vibro);
                     }
                 } else if(event->key == InputKeyOk) {
                     model->ptt_pressed = true;
-                    if (model->muted) {
-                        hid_ptt_start_ptt(hid_ptt, model);
+                    if (model->mic_pressed){
+                        // Change local mic status
+                        model->muted = !model->muted;
+                        model->mic_sync_pressed = true;
+                        notification_message(hid_ptt->hid->notifications, &sequence_single_vibro);
+                    } else {
+                        if (model->muted) {
+                            hid_ptt_start_ptt(hid_ptt, model);
+                        }
                     }
                 } else if(event->key == InputKeyBack) {
                     model->mic_pressed = true;
@@ -327,12 +358,12 @@ static void hid_ptt_process(HidPtt* hid_ptt, InputEvent* event) {
             } else if(event->type == InputTypeRelease) {
                 if(event->key == InputKeyUp) {
                     model->up_pressed = false;
-                    if (!model->ptt_pressed){
+                    if (!model->mic_pressed && !model->ptt_pressed){
                         hid_hal_consumer_key_release(hid_ptt->hid, HID_CONSUMER_VOLUME_INCREMENT);
                     }
                 } else if(event->key == InputKeyDown) {
                     model->down_pressed = false;
-                    if (!model->ptt_pressed){
+                    if (!model->mic_pressed && !model->ptt_pressed){
                         hid_hal_consumer_key_release(hid_ptt->hid, HID_CONSUMER_VOLUME_DECREMENT);
                     }
                 } else if(event->key == InputKeyLeft) {
@@ -342,44 +373,41 @@ static void hid_ptt_process(HidPtt* hid_ptt, InputEvent* event) {
 
                 } else if(event->key == InputKeyOk) {
                     model->ptt_pressed = false;
-                    if (model->muted) {
-                        hid_ptt_stop_ptt(hid_ptt, model);
-                    } else {
-                        hid_ptt_trigger_mute(hid_ptt, model);
-                        model->muted = true;
+                    if(!model->mic_pressed && !model->mic_sync_pressed) {
+                        if (model->muted) {
+                            hid_ptt_stop_ptt(hid_ptt, model);
+                        } else {
+                            hid_ptt_trigger_mute(hid_ptt, model);
+                            model->muted = true;
+                        }
                     }
+                    model->mic_sync_pressed = false;
                 } else if(event->key == InputKeyBack) {
                     model->mic_pressed = false;
                 }
-            } else if(event->type == InputTypeShort) {
-                if(event->key == InputKeyBack && !model->ptt_pressed ) { // no changes if PTT is pressed
+            } else if(event->type == InputTypeShort && !model->ptt_pressed) {
+                if(event->key == InputKeyBack ) { // no changes if PTT is pressed
                     model->muted = !model->muted;
                     hid_ptt_trigger_mute(hid_ptt, model);
                 } else if(event->key == InputKeyRight) {
-                    if (!model->ptt_pressed){
+                    if (!model->mic_pressed){
                         hid_ptt_trigger_camera(hid_ptt, model);
                     }
                 }
-            } else if(event->type == InputTypeLong) {
-                if(event->key == InputKeyLeft) {
-                    model->left_pressed = false;
-                    if (!model->ptt_pressed){
-                        hid_hal_keyboard_release_all(hid_ptt->hid);
-                        view_dispatcher_switch_to_view(hid_ptt->hid->view_dispatcher, HidViewSubmenu);
-                        // sequence_double_vibro to notify that we quit PTT
-                        notification_message(hid_ptt->hid->notifications, &sequence_double_vibro);
-                    }
-                } else if(event->key == InputKeyBack && !model->ptt_pressed ) { // no changes if PTT is pressed
-                    // Change local mic status
-                    model->muted = !model->muted;
-                    notification_message(hid_ptt->hid->notifications, &sequence_single_vibro);
+            } else if(event->type == InputTypeLong && event->key == InputKeyLeft) {
+                model->left_pressed = false;
+                if (!model->ptt_pressed){
+                    hid_hal_keyboard_release_all(hid_ptt->hid);
+                    view_dispatcher_switch_to_view(hid_ptt->hid->view_dispatcher, HidViewSubmenu);
+                    // sequence_double_vibro to notify that we quit PTT
+                    notification_message(hid_ptt->hid->notifications, &sequence_double_vibro);
                 }
             }
             //LED
-            if (model->muted && !model->ptt_pressed) {
-                notification_message(hid_ptt->hid->notifications, &sequence_reset_red);
-            } else {
+            if (!model->muted || (model->ptt_pressed && !model->mic_sync_pressed)) {
                 notification_message(hid_ptt->hid->notifications, &sequence_set_red_255);
+            } else {
+                notification_message(hid_ptt->hid->notifications, &sequence_reset_red);
             }
         },
         true);
@@ -408,6 +436,7 @@ HidPtt* hid_ptt_alloc(Hid* hid) {
             model->transport = hid->transport;
             model->muted = true; // assume we're muted
             model->is_mac_os = true;
+            model->mic_sync_pressed = false;
         }, true);
     return hid_ptt;
 }


### PR DESCRIPTION
- Removed exit confirmation dialog
- Implemented "Hold back to exit" for all the menus (except PTT)
- Removed all PTT+ combinations to avoid accidental settings changes when "transmitting"

![ptt-safe](https://github.com/xMasterX/all-the-plugins/assets/1643962/0fbc81f1-192c-40ea-92f8-bce5155d6bf7)  ![ptt-safe+](https://github.com/xMasterX/all-the-plugins/assets/1643962/ecbd0980-cefe-49db-8d83-72d390a468f9)  ![ptt-safe++](https://github.com/xMasterX/all-the-plugins/assets/1643962/8a2be2e1-6581-4d3c-af0b-b5e2c78a3818)
