### PR TITLE
PTT: fixed 'raise hand' for zoom on mac

### DIFF
--- a/base_pack/hid_app/views/hid_ptt.c
+++ b/base_pack/hid_app/views/hid_ptt.c
@@ -104,11 +104,7 @@ static void hid_ptt_trigger_camera_linux_zoom(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(  hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_V);
     hid_hal_keyboard_release(hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_V);
 }
-static void hid_ptt_trigger_hand_macos_zoom(HidPushToTalk* hid_ptt) {
-    hid_hal_keyboard_press(  hid_ptt->hid, KEY_MOD_LEFT_GUI| HID_KEYBOARD_Y);
-    hid_hal_keyboard_release(hid_ptt->hid, KEY_MOD_LEFT_GUI| HID_KEYBOARD_Y);
-}
-static void hid_ptt_trigger_hand_linux_zoom(HidPushToTalk* hid_ptt) {
+static void hid_ptt_trigger_hand_zoom(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(  hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_Y);
     hid_hal_keyboard_release(hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_Y);
 }
@@ -363,7 +359,7 @@ static void hid_ptt_menu_callback(void* context, uint32_t osIndex, FuriString* o
                 case HidPushToTalkAppIndexZoom:
                     model->callback_trigger_mute   = hid_ptt_trigger_mute_macos_zoom;
                     model->callback_trigger_camera = hid_ptt_trigger_camera_macos_zoom;
-                    model->callback_trigger_hand   = hid_ptt_trigger_hand_macos_zoom;
+                    model->callback_trigger_hand   = hid_ptt_trigger_hand_zoom;
                     model->callback_start_ptt      = hid_ptt_start_ptt_meet_zoom;
                     model->callback_stop_ptt       = hid_ptt_stop_ptt_meet_zoom;
                     break;
@@ -431,7 +427,7 @@ static void hid_ptt_menu_callback(void* context, uint32_t osIndex, FuriString* o
                 case HidPushToTalkAppIndexZoom:
                     model->callback_trigger_mute   = hid_ptt_trigger_mute_linux_zoom;
                     model->callback_trigger_camera = hid_ptt_trigger_camera_linux_zoom;
-                    model->callback_trigger_hand   = hid_ptt_trigger_hand_linux_zoom;
+                    model->callback_trigger_hand   = hid_ptt_trigger_hand_zoom;
                     model->callback_start_ptt      = hid_ptt_start_ptt_meet_zoom;
                     model->callback_stop_ptt       = hid_ptt_stop_ptt_meet_zoom;
                     break;


### PR DESCRIPTION
It turned out raise hand zoom shortcut for mac was misconfigured, fixed.