### PR TITLE
Countdown Timer: Some small fixes and improvements

### DIFF
--- a/apps_source_code/fpz_cntdown_timer-main/utils/utils.c
+++ b/apps_source_code/fpz_cntdown_timer-main/utils/utils.c
@@ -10,6 +10,42 @@ static const NotificationSequence sequence_beep = {
     NULL,
 };
 
+static const NotificationSequence sequence_timeup = {
+    &message_force_display_brightness_setting_1f,
+    &message_display_backlight_on,
+    &message_vibro_on,
+
+    &message_note_c8,
+    &message_delay_50,
+    &message_sound_off,
+    &message_delay_50,
+    &message_delay_25,
+
+    &message_note_c8,
+    &message_delay_50,
+    &message_sound_off,
+    &message_delay_50,
+    &message_delay_25,
+
+    &message_note_c8,
+    &message_delay_50,
+    &message_sound_off,
+    &message_delay_50,
+    &message_delay_25,
+
+    &message_note_c8,
+    &message_delay_50,
+    &message_sound_off,
+    &message_delay_50,
+    &message_delay_25,
+
+    &message_vibro_off,
+    &message_display_backlight_off,
+    &message_delay_500,
+
+    NULL,
+};
+
 void notification_beep_once() {
     notification_message(furi_record_open(RECORD_NOTIFICATION), &sequence_beep);
     notification_off();
@@ -20,7 +56,7 @@ void notification_off() {
 }
 
 void notification_timeup() {
-    notification_message(furi_record_open(RECORD_NOTIFICATION), &sequence_audiovisual_alert);
+    notification_message(furi_record_open(RECORD_NOTIFICATION), &sequence_timeup);
 }
 
 void parse_sec_to_time_str(char* buffer, size_t len, int32_t sec) {

--- a/apps_source_code/fpz_cntdown_timer-main/views/countdown_view.c
+++ b/apps_source_code/fpz_cntdown_timer-main/views/countdown_view.c
@@ -307,13 +307,11 @@ static void handle_time_setting_select(InputKey key, CountDownTimView* cdv) {
         break;
 
     case InputKeyRight:
-        selection--;
-        selection = selection % 3;
+        selection = (3 + selection - 1) % 3;
         break;
 
     case InputKeyLeft:
-        selection++;
-        selection = selection % 3;
+        selection = (3 + selection + 1) % 3;
         break;
 
     default:

--- a/apps_source_code/fpz_cntdown_timer-main/views/countdown_view.c
+++ b/apps_source_code/fpz_cntdown_timer-main/views/countdown_view.c
@@ -93,7 +93,7 @@ static void countdown_timer_view_on_draw(Canvas* canvas, void* ctx) {
     char buffer[64];
 
     int32_t count = model->count;
-    int32_t expected_count = model->saved_count_setting;
+    int32_t expected_count = MAX(model->saved_count_setting, 1);
 
     CountDownViewSelect select = model->select;
 


### PR DESCRIPTION
In order of commit:
 - fc77cfef7348ba989d963c1656015292243f482a Replaces the alarm-like timeup alert with one faithfully modeled after a typical digital kitchen timer (which now follows volume/vibration settings)
 - 25fcd733b071a39c855497a6dce68e41ba4045c6 Fixes a divide-by-zero error when setting the time to zero seconds. Has since been made somewhat superfluous by 1bd63df18078bb910c35acc4972a76dc405453cc no longer allowing that in the first place, but the additional hardening doesn't hurt.
 - b967b6b7977507bd36b57a15c3ae5a1ce71c0238 Fixes the math for wrapping the hour/minute/second selection, allowing it to wrap in both directions.

Further details can be found in the description for each commit