### PR TITLE
WAV Player: Reconfigure to use 8-bit memory buffer, halving memory usage

### DIFF
--- a/base_pack/wav_player/wav_parser.h
+++ b/base_pack/wav_player/wav_parser.h
@@ -50,7 +50,7 @@ typedef struct {
     Storage* storage;
     Stream* stream;
     WavParser* parser;
-    uint16_t* sample_buffer;
+    uint8_t* sample_buffer;
     uint8_t* tmp_buffer;
 
     uint32_t sample_rate;

--- a/base_pack/wav_player/wav_player.c
+++ b/base_pack/wav_player/wav_player.c
@@ -86,8 +86,8 @@ static WavPlayerApp* app_alloc() {
     app->storage = furi_record_open(RECORD_STORAGE);
     app->stream = file_stream_alloc(app->storage);
     app->parser = wav_parser_alloc();
-    app->sample_buffer = malloc(sizeof(uint16_t) * app->samples_count);
-    app->tmp_buffer = malloc(sizeof(uint8_t) * app->samples_count);
+    app->sample_buffer = malloc(sizeof(*app->sample_buffer) * app->samples_count);
+    app->tmp_buffer = malloc(sizeof(*app->tmp_buffer) * app->samples_count);
     app->queue = furi_message_queue_alloc(10, sizeof(WavPlayerEvent));
 
     app->volume = 10.0f;
@@ -128,7 +128,7 @@ static void app_free(WavPlayerApp* app) {
 // TODO: that works only with 8-bit 2ch audio
 static bool fill_data(WavPlayerApp* app, size_t index) {
     if(app->num_channels == 1 && app->bits_per_sample == 8) {
-        uint16_t* sample_buffer_start = &app->sample_buffer[index];
+        uint8_t* sample_buffer_start = &app->sample_buffer[index];
         size_t count = stream_read(app->stream, app->tmp_buffer, app->samples_count_half);
 
         for(size_t i = count; i < app->samples_count_half; i++) {
@@ -167,7 +167,7 @@ static bool fill_data(WavPlayerApp* app, size_t index) {
     }
 
     if(app->num_channels == 1 && app->bits_per_sample == 16) {
-        uint16_t* sample_buffer_start = &app->sample_buffer[index];
+        uint8_t* sample_buffer_start = &app->sample_buffer[index];
         size_t count = stream_read(app->stream, app->tmp_buffer, app->samples_count);
 
         for(size_t i = count; i < app->samples_count; i++) {
@@ -205,7 +205,7 @@ static bool fill_data(WavPlayerApp* app, size_t index) {
     }
 
     if(app->num_channels == 2 && app->bits_per_sample == 16) {
-        uint16_t* sample_buffer_start = &app->sample_buffer[index];
+        uint8_t* sample_buffer_start = &app->sample_buffer[index];
         size_t count = stream_read(app->stream, app->tmp_buffer, app->samples_count);
 
         for(size_t i = 0; i < app->samples_count; i += 4) {
@@ -268,7 +268,7 @@ static bool fill_data(WavPlayerApp* app, size_t index) {
     }
 
     if(app->num_channels == 2 && app->bits_per_sample == 8) {
-        uint16_t* sample_buffer_start = &app->sample_buffer[index];
+        uint8_t* sample_buffer_start = &app->sample_buffer[index];
         size_t count = stream_read(app->stream, app->tmp_buffer, app->samples_count);
 
         for(size_t i = count; i < app->samples_count; i++) {

--- a/base_pack/wav_player/wav_player_hal.c
+++ b/base_pack/wav_player/wav_player_hal.c
@@ -38,7 +38,7 @@ void wav_player_speaker_init(uint32_t sample_rate) {
     TIM_InitStruct.Prescaler = 0;
     //TIM_InitStruct.Autoreload = 1451; //64 000 000 / 1451 ~= 44100 Hz
 
-    TIM_InitStruct.Autoreload = 64000000 / sample_rate - 1; //to support various sample rates
+    TIM_InitStruct.Autoreload = SystemCoreClock / sample_rate - 1; //to support various sample rates
 
     LL_TIM_Init(SAMPLE_RATE_TIMER, &TIM_InitStruct);
 
@@ -95,7 +95,7 @@ void wav_player_dma_init(uint32_t address, size_t size) {
     LL_DMA_SetPeriphIncMode(DMA_INSTANCE, LL_DMA_PERIPH_NOINCREMENT);
     LL_DMA_SetMemoryIncMode(DMA_INSTANCE, LL_DMA_MEMORY_INCREMENT);
     LL_DMA_SetPeriphSize(DMA_INSTANCE, LL_DMA_PDATAALIGN_HALFWORD);
-    LL_DMA_SetMemorySize(DMA_INSTANCE, LL_DMA_MDATAALIGN_HALFWORD);
+    LL_DMA_SetMemorySize(DMA_INSTANCE, LL_DMA_MDATAALIGN_BYTE);
 
     LL_DMA_EnableIT_TC(DMA_INSTANCE);
     LL_DMA_EnableIT_HT(DMA_INSTANCE);

--- a/base_pack/wav_player/wav_player_view.c
+++ b/base_pack/wav_player/wav_player_view.c
@@ -174,7 +174,7 @@ void wav_player_view_set_bits(WavPlayerView* wav_view, uint16_t bit) {
         wav_view->view, WavPlayerViewModel * model, { model->bits_per_sample = bit; }, true);
 }
 
-void wav_player_view_set_data(WavPlayerView* wav_view, uint16_t* data, size_t data_count) {
+void wav_player_view_set_data(WavPlayerView* wav_view, uint8_t* data, size_t data_count) {
     furi_assert(wav_view);
     with_view_model(
         wav_view->view,

--- a/base_pack/wav_player/wav_player_view.h
+++ b/base_pack/wav_player/wav_player_view.h
@@ -64,7 +64,7 @@ void wav_player_view_set_current(WavPlayerView* wav_view, size_t current);
 
 void wav_player_view_set_play(WavPlayerView* wav_view, bool play);
 
-void wav_player_view_set_data(WavPlayerView* wav_view, uint16_t* data, size_t data_count);
+void wav_player_view_set_data(WavPlayerView* wav_view, uint8_t* data, size_t data_count);
 
 void wav_player_view_set_bits(WavPlayerView* wav_view, uint16_t bit);
 void wav_player_view_set_chans(WavPlayerView* wav_view, uint16_t chn);


### PR DESCRIPTION
The WAV Player configures the memory side of the DMA transfer to halfword (16 bits), even though the end result of the WAV decoding is always within the `u8` range. This PR modifies the transfer config to byte (8 bits), as STM32WB55 specifically allows to mismatch memory and peripheral data sizes.

This effectively reduces the memory usage of the app by approximately 1/3 (16bit buffer + 8bit buffer -> 8bit buffer + 8bit buffer).