### PR TITLE
Fix apps using the View Dispatcher without running it

### DIFF
--- a/apps_source_code/musictracker/application.fam
+++ b/apps_source_code/musictracker/application.fam
@@ -12,6 +12,6 @@ App(
     fap_category="Media",
     fap_author="@DrZlo13",
     fap_weburl="https://github.com/DrZlo13/flipper-zero-music-tracker",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_description="App plays hardcoded tracker song",
 )

--- a/apps_source_code/musictracker/tracker_engine/tracker.c
+++ b/apps_source_code/musictracker/tracker_engine/tracker.c
@@ -154,25 +154,25 @@ typedef struct {
 
 static void tracker_send_position_message(Tracker* tracker) {
     if(tracker->callback != NULL) {
-        tracker->callback(
-            (TrackerMessage){
-                .type = TrackerPositionChanged,
-                .data =
-                    {
-                        .position =
-                            {
-                                .order_list_index = tracker->song_state.order_list_index,
-                                .row = tracker->song_state.row_index,
-                            },
-                    },
-            },
-            tracker->context);
+        const TrackerMessage message = {
+            .type = TrackerPositionChanged,
+            .data =
+                {
+                    .position =
+                        {
+                            .order_list_index = tracker->song_state.order_list_index,
+                            .row = tracker->song_state.row_index,
+                        },
+                },
+        };
+        tracker->callback(&message, tracker->context);
     }
 }
 
 static void tracker_send_end_message(Tracker* tracker) {
     if(tracker->callback != NULL) {
-        tracker->callback((TrackerMessage){.type = TrackerEndOfSong}, tracker->context);
+        const TrackerMessage message = {.type = TrackerEndOfSong};
+        tracker->callback(&message, tracker->context);
     }
 }
 

--- a/apps_source_code/musictracker/tracker_engine/tracker.h
+++ b/apps_source_code/musictracker/tracker_engine/tracker.h
@@ -5,6 +5,7 @@
 typedef enum {
     TrackerPositionChanged,
     TrackerEndOfSong,
+    TrackerShutDown,
 } TrackerMessageType;
 
 typedef struct {
@@ -17,7 +18,7 @@ typedef struct {
     } data;
 } TrackerMessage;
 
-typedef void (*TrackerMessageCallback)(TrackerMessage message, void* context);
+typedef void (*TrackerMessageCallback)(const TrackerMessage* message, void* context);
 
 typedef struct Tracker Tracker;
 

--- a/apps_source_code/musictracker/view/tracker_view.c
+++ b/apps_source_code/musictracker/view/tracker_view.c
@@ -10,8 +10,6 @@ typedef struct {
 
 struct TrackerView {
     View* view;
-    void* back_context;
-    TrackerViewCallback back_callback;
 };
 
 static Channel* get_current_channel(TrackerViewModel* model) {
@@ -126,25 +124,12 @@ static void tracker_view_draw_callback(Canvas* canvas, void* _model) {
     furi_string_free(buffer);
 }
 
-static bool tracker_view_input_callback(InputEvent* event, void* context) {
-    TrackerView* tracker_view = context;
-
-    if(tracker_view->back_callback) {
-        if(event->type == InputTypeShort && event->key == InputKeyBack) {
-            tracker_view->back_callback(tracker_view->back_context);
-            return true;
-        }
-    }
-    return false;
-}
-
 TrackerView* tracker_view_alloc() {
     TrackerView* tracker_view = malloc(sizeof(TrackerView));
     tracker_view->view = view_alloc();
     view_allocate_model(tracker_view->view, ViewModelTypeLocking, sizeof(TrackerViewModel));
     view_set_context(tracker_view->view, tracker_view);
-    view_set_draw_callback(tracker_view->view, (ViewDrawCallback)tracker_view_draw_callback);
-    view_set_input_callback(tracker_view->view, (ViewInputCallback)tracker_view_input_callback);
+    view_set_draw_callback(tracker_view->view, tracker_view_draw_callback);
     return tracker_view;
 }
 
@@ -155,14 +140,6 @@ void tracker_view_free(TrackerView* tracker_view) {
 
 View* tracker_view_get_view(TrackerView* tracker_view) {
     return tracker_view->view;
-}
-
-void tracker_view_set_back_callback(
-    TrackerView* tracker_view,
-    TrackerViewCallback callback,
-    void* context) {
-    tracker_view->back_callback = callback;
-    tracker_view->back_context = context;
 }
 
 void tracker_view_set_song(TrackerView* tracker_view, const Song* song) {

--- a/apps_source_code/musictracker/view/tracker_view.h
+++ b/apps_source_code/musictracker/view/tracker_view.h
@@ -13,13 +13,6 @@ void tracker_view_free(TrackerView* tracker_view);
 
 View* tracker_view_get_view(TrackerView* tracker_view);
 
-typedef void (*TrackerViewCallback)(void* context);
-
-void tracker_view_set_back_callback(
-    TrackerView* tracker_view,
-    TrackerViewCallback callback,
-    void* context);
-
 void tracker_view_set_song(TrackerView* tracker_view, const Song* song);
 
 void tracker_view_set_position(TrackerView* tracker_view, uint8_t order_list_index, uint8_t row);

--- a/base_pack/wav_player/application.fam
+++ b/base_pack/wav_player/application.fam
@@ -9,6 +9,6 @@ App(
     fap_category="Media",
     fap_icon_assets="images",
     fap_author="@DrZlo13 & (ported, fixed by @xMasterX), (improved by @LTVA1)",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_description="Audio player for WAV files, recommended to convert files to unsigned 8-bit PCM stereo, but it may work with others too",
 )

--- a/base_pack/wav_player/wav_parser.h
+++ b/base_pack/wav_player/wav_parser.h
@@ -3,12 +3,10 @@
 
 #include <furi.h>
 #include <furi_hal.h>
-#include <cli/cli.h>
 #include <gui/gui.h>
-#include <stm32wbxx_ll_dma.h>
 #include <dialogs/dialogs.h>
 #include <notification/notification_messages.h>
-#include <gui/view_dispatcher.h>
+#include <gui/view_holder.h>
 #include <toolbox/stream/file_stream.h>
 
 #include "wav_player_view.h"
@@ -67,7 +65,7 @@ typedef struct {
     bool play;
 
     WavPlayerView* view;
-    ViewDispatcher* view_dispatcher;
+    ViewHolder* view_holder;
     Gui* gui;
     NotificationApp* notification;
 } WavPlayerApp;

--- a/base_pack/wav_player/wav_player_view.c
+++ b/base_pack/wav_player/wav_player_view.c
@@ -100,9 +100,6 @@ static bool wav_player_view_input_callback(InputEvent* event, void* context) {
             } else if(event->key == InputKeyOk) {
                 wav_player_view->callback(WavPlayerCtrlOk, wav_player_view->context);
                 consumed = true;
-            } else if(event->key == InputKeyBack) {
-                wav_player_view->callback(WavPlayerCtrlBack, wav_player_view->context);
-                consumed = true;
             }
         }
     }
@@ -134,20 +131,17 @@ View* wav_player_view_get_view(WavPlayerView* wav_view) {
 
 void wav_player_view_set_volume(WavPlayerView* wav_view, float volume) {
     furi_assert(wav_view);
-    with_view_model(
-        wav_view->view, WavPlayerViewModel * model, { model->volume = volume; }, true);
+    with_view_model(wav_view->view, WavPlayerViewModel * model, { model->volume = volume; }, true);
 }
 
 void wav_player_view_set_start(WavPlayerView* wav_view, size_t start) {
     furi_assert(wav_view);
-    with_view_model(
-        wav_view->view, WavPlayerViewModel * model, { model->start = start; }, true);
+    with_view_model(wav_view->view, WavPlayerViewModel * model, { model->start = start; }, true);
 }
 
 void wav_player_view_set_end(WavPlayerView* wav_view, size_t end) {
     furi_assert(wav_view);
-    with_view_model(
-        wav_view->view, WavPlayerViewModel * model, { model->end = end; }, true);
+    with_view_model(wav_view->view, WavPlayerViewModel * model, { model->end = end; }, true);
 }
 
 void wav_player_view_set_current(WavPlayerView* wav_view, size_t current) {
@@ -158,8 +152,7 @@ void wav_player_view_set_current(WavPlayerView* wav_view, size_t current) {
 
 void wav_player_view_set_play(WavPlayerView* wav_view, bool play) {
     furi_assert(wav_view);
-    with_view_model(
-        wav_view->view, WavPlayerViewModel * model, { model->play = play; }, true);
+    with_view_model(wav_view->view, WavPlayerViewModel * model, { model->play = play; }, true);
 }
 
 void wav_player_view_set_chans(WavPlayerView* wav_view, uint16_t chn) {

--- a/base_pack/wav_player/wav_player_view.h
+++ b/base_pack/wav_player/wav_player_view.h
@@ -3,13 +3,7 @@
 
 #include <furi.h>
 #include <furi_hal.h>
-#include <cli/cli.h>
-#include <gui/gui.h>
-#include <stm32wbxx_ll_dma.h>
-#include <dialogs/dialogs.h>
-#include <notification/notification_messages.h>
-#include <gui/view_dispatcher.h>
-#include <toolbox/stream/file_stream.h>
+#include <gui/view.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,7 +17,6 @@ typedef enum {
     WavPlayerCtrlMoveL,
     WavPlayerCtrlMoveR,
     WavPlayerCtrlOk,
-    WavPlayerCtrlBack,
 } WavPlayerCtrl;
 
 typedef void (*WavPlayerCtrlCallback)(WavPlayerCtrl ctrl, void* context);


### PR DESCRIPTION
This PR fixes apps that had input processing broken after https://github.com/flipperdevices/flipperzero-firmware/pull/3703. When the upgraded View Dispatcher was used without running it with `view_dispatcher_run`, the event queue on the UI thread eventually clogged, and it wasn't letting the app message pumps process inputs to begin with. For these cases, I migrated the apps to use a View Holder as the firmware PR recommends.

The following apps have been upgraded:
* WAV Player
* Zero Tracker - exit controls were not functional there **at all** before, I now properly wired them up to the View Holder

The following apps have **not** been upgraded:
* Flizzer Tracker - technically broken, but the version in this repo appears to be outdated, and the maintained version here https://github.com/LTVA1/flizzer_tracker already addressed this issue
* Video Player - while the View Dispatcher is technically used here, no issues occur because it quickly gets replaced with Direct Draw. Additionally, this repo's copy again appears to be outdated, with https://github.com/LTVA1/flipper-zero-video-player/tree/main/flipper_project being the latest.

Both apps now also respect the `loader stop` thread signal.