### PR TITLE
Update README.md

### DIFF
--- a/base_pack/gps_nmea_uart/README.md
+++ b/base_pack/gps_nmea_uart/README.md
@@ -46,6 +46,7 @@ the hardware setup.
 * u-blox NEO-6M
 * u-blox NEO-7M
 * Uputronics u-blox MAX-M8C Pico
+* NewHail GNSS Modul
 
 If you have verified this application working with a module not listed here,
 please submit a PR adding it to the list.


### PR DESCRIPTION
NewHail GNSS Modul

works 😃

Technical data:

Module-Chip

L76K
GNSS antenna (supports GPS L1 C/A, BDS B1 and GLONASS L1 bands)

1584R-A E