### PR TITLE
Bugfix for Caesar Cipher app

### DIFF
--- a/apps_source_code/caesarcipher/caesar_cipher.c
+++ b/apps_source_code/caesarcipher/caesar_cipher.c
@@ -90,11 +90,14 @@ static void caesar_cipher_state_init(CaesarState* const caesar_state) {
 }
 
 static void caesar_cipher_state_free(CaesarState* const caesar_state) {
-    text_input_free(caesar_state->text_input);
-    text_box_free(caesar_state->text_box);
     view_dispatcher_remove_view(caesar_state->view_dispatcher, 0);
     view_dispatcher_remove_view(caesar_state->view_dispatcher, 1);
     view_dispatcher_free(caesar_state->view_dispatcher);
+
+    text_input_free(caesar_state->text_input);
+    text_box_free(caesar_state->text_box);
+
+    furi_mutex_free(caesar_state->mutex);
     free(caesar_state);
 }
 


### PR DESCRIPTION
When exiting the output screen, the app would crash a good amount of the time. I reordered the free statements in caesar_cipher_state_free() to fix this issue.