### PR TITLE
Segment clock and HC-SR04 app improvements

### DIFF
--- a/apps_source_code/segment_clock/README.md
+++ b/apps_source_code/segment_clock/README.md
@@ -1,3 +1,3 @@
 # What is this?
 
-Simple segment clock.
+Simple segment clock. Press the up button to toggle between 12 and 24 hour mode.

--- a/apps_source_code/segment_clock/application.fam
+++ b/apps_source_code/segment_clock/application.fam
@@ -11,7 +11,7 @@ App(
     fap_icon="icon.png",
     fap_category="Tools",
     fap_author="sergo",
-    fap_version="1.0",
+    fap_version="1.1",
     fap_weburl="https://github.com/Sladkisnovraper/Segment-Clock-For-Flipper-Zero",
     fap_description="Display simple segment clock on Flipper screen",
     sources=["*.c"]

--- a/apps_source_code/segment_clock/catalog/docs/Changelog.md
+++ b/apps_source_code/segment_clock/catalog/docs/Changelog.md
@@ -1,3 +1,6 @@
+## v1.1
+- Add toggle between 12 and 24 hour mode (by @Tyl3rA)
+
 ## v1.0
 
 **Initial implementation:**

--- a/apps_source_code/segment_clock/catalog/docs/Readme.md
+++ b/apps_source_code/segment_clock/catalog/docs/Readme.md
@@ -1,1 +1,1 @@
-Display simple segment clock on Flipper screen.
+Display a simple segment clock on the Flipper screen. Press the up button to toggle between 12 and 24 hour mode.

--- a/apps_source_code/segment_clock/main.c
+++ b/apps_source_code/segment_clock/main.c
@@ -22,6 +22,7 @@ typedef struct {
     DateTime datetime;
     bool running;
     bool colon_state;
+    int mode; // 12 or 24 hour mode
 } SegmentClock;
 
 /*
@@ -186,8 +187,18 @@ static void draw_callback(Canvas* canvas, void* ctx) {
     uint8_t start_y = (screen_height - VERTICAL_HEIGHT * 2 - SEGMENT_HEIGHT) / 2;
 
     // Draw hours
-    draw_digit(canvas, start_x, start_y, hours / 10);
-    draw_digit(canvas, start_x + digit_width + digit_spacing, start_y, hours % 10);
+    if (clock->mode == 12) {
+        // Convert to 12-hour format
+        uint8_t display_hours = hours % 12;
+        if (display_hours == 0) display_hours = 12; // Handle midnight/noon case
+
+        draw_digit(canvas, start_x, start_y, display_hours / 10);
+        draw_digit(canvas, start_x + digit_width + digit_spacing, start_y, display_hours % 10);
+    } else {
+        // no modification for 24 hour mode
+        draw_digit(canvas, start_x, start_y, hours / 10);
+        draw_digit(canvas, start_x + digit_width + digit_spacing, start_y, hours % 10);
+    }
 
     // Draw colon (только если colon_state == true)
     if(clock->colon_state) {
@@ -235,6 +246,7 @@ int32_t clock_app(void* p) {
     clock->input_queue = furi_message_queue_alloc(8, sizeof(InputEvent));
     clock->running = true;
     clock->colon_state = true;  // Инициализируем состояние двоеточия
+    clock->mode = 24;
 
     // Setup view port
     clock->view_port = view_port_alloc();
@@ -263,6 +275,15 @@ int32_t clock_app(void* p) {
         if(furi_message_queue_get(clock->input_queue, &event, 100) == FuriStatusOk) {
             if(event.type == InputTypeShort && event.key == InputKeyBack) {
                 clock->running = false;
+            }
+
+            if (event.type == InputTypeShort && event.key == InputKeyUp) {
+                // switch between 12 and 24 hour time
+                if (clock->mode == 12) {
+                    clock->mode = 24;
+                } else {
+                    clock->mode = 12;
+                }
             }
         }
     }

--- a/base_pack/hc_sr04/hc_sr04.c
+++ b/base_pack/hc_sr04/hc_sr04.c
@@ -30,6 +30,7 @@ typedef struct {
     bool measurement_made;
     uint32_t echo; // us
     float distance; // meters
+    int mode; // 1 = m, 2 = cm, 3 = ft, 4 = in
 } PluginState;
 
 const NotificationSequence sequence_done = {
@@ -40,6 +41,18 @@ const NotificationSequence sequence_done = {
     &message_sound_off,
     NULL,
 };
+
+float m_to_cm(float meters) {
+    return meters * 100.0f;
+}
+
+float m_to_feet(float meters) {
+    return meters * 3.28084f;
+}
+
+float m_to_inches(float meters) {
+    return meters * 39.3701f;
+}
 
 static void render_callback(Canvas* const canvas, void* ctx) {
     furi_assert(ctx);
@@ -78,7 +91,17 @@ static void render_callback(Canvas* const canvas, void* ctx) {
 
             canvas_draw_str_aligned(
                 canvas, 8, 38, AlignLeft, AlignTop, furi_string_get_cstr(str_buf));
-            furi_string_printf(str_buf, "Distance: %02f m", (double)plugin_state->distance);
+
+            if (plugin_state->mode == 1) {
+                furi_string_printf(str_buf, "Distance: %02f m", (double)plugin_state->distance);
+            } else if (plugin_state->mode == 2) {
+                furi_string_printf(str_buf, "Distance: %02f cm", (double)m_to_cm(plugin_state->distance));
+            } else if (plugin_state->mode == 3) {
+                furi_string_printf(str_buf, "Distance: %02f ft", (double)m_to_feet(plugin_state->distance));
+            } else if (plugin_state->mode == 4) {
+                furi_string_printf(str_buf, "Distance: %02f in", (double)m_to_inches(plugin_state->distance));
+            }
+
             canvas_draw_str_aligned(
                 canvas, 8, 48, AlignLeft, AlignTop, furi_string_get_cstr(str_buf));
 
@@ -188,6 +211,8 @@ int32_t hc_sr04_app() {
 
     hc_sr04_state_init(plugin_state);
 
+    plugin_state->mode = 1; // meters as default
+
     FuriHalSerialHandle* serial_handle = furi_hal_serial_control_acquire(FuriHalSerialIdUsart);
 
     plugin_state->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
@@ -230,8 +255,14 @@ int32_t hc_sr04_app() {
                     switch(event.input.key) {
                     case InputKeyUp:
                     case InputKeyDown:
+                        break;
                     case InputKeyRight:
+                        plugin_state->mode++;
+                        if(plugin_state->mode > 4) plugin_state->mode = 1;
+                        break;
                     case InputKeyLeft:
+                        plugin_state->mode--;
+                        if(plugin_state->mode < 1) plugin_state->mode = 4;
                         break;
                     case InputKeyOk:
                         hc_sr04_measure(plugin_state);


### PR DESCRIPTION
Updated the segment clock app so when the up arrow is pressed it toggles the time between 12 and 24 hour time modes. Updated both readme files to show users this change and bumped the version in the .fam and changelog.

I also added a distance format toggle in the HC-SR04 app so pressing left / right changes the distance format between meters, centimeters, feet, and inches.