### PR TITLE
[NFC Magic]: Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard

### DIFF
--- a/base_pack/nfc_magic/application.fam
+++ b/base_pack/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="1.11",
+    fap_version="1.12",
     fap_icon="assets/Nfc_10px.png",
     fap_category="NFC",
     fap_icon_assets="assets",

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.c
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.c
@@ -6,6 +6,7 @@
 #include "protocols/gen2/gen2_poller.h"
 #include "protocols/gen4/gen4_poller.h"
 #include <nfc/nfc_poller.h>
+#include <nfc/protocols/iso14443_3a/iso14443_3a.h>
 
 #include <furi/furi.h>
 
@@ -23,6 +24,7 @@ struct NfcMagicScanner {
     Gen4Password gen4_password;
     Gen4* gen4_data;
     Gen2Type gen2_type;
+    uint8_t gen1_uid_len;
     bool magic_protocol_detected;
 
     NfcMagicScannerCallback callback;
@@ -41,6 +43,7 @@ static void nfc_magic_scanner_reset(NfcMagicScanner* instance) {
     instance->session_state = NfcMagicScannerSessionStateIdle;
     instance->current_protocol = NfcMagicProtocolGen1;
     instance->gen2_type = Gen2TypeUnknown;
+    instance->gen1_uid_len = 0;
 }
 
 NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc) {
@@ -66,6 +69,20 @@ void nfc_magic_scanner_set_gen4_password(NfcMagicScanner* instance, Gen4Password
     instance->gen4_password = password;
 }
 
+// Reads the card's UID length (4 or 7) via a standard ISO14443-3A activation, or 0 if
+// it can't be determined. Gen1's backdoor wakeup is UID-length-agnostic, so this
+// resolves the anticollision cascade to tell 4-byte and 7-byte Gen1 tags apart.
+static uint8_t nfc_magic_scanner_read_uid_len(Nfc* nfc) {
+    uint8_t uid_len = 0;
+    NfcPoller* poller = nfc_poller_alloc(nfc, NfcProtocolIso14443_3a);
+    if(nfc_poller_detect(poller)) {
+        const Iso14443_3aData* data = nfc_poller_get_data(poller);
+        uid_len = data->uid_len;
+    }
+    nfc_poller_free(poller);
+    return uid_len;
+}
+
 static int32_t nfc_magic_scanner_worker(void* context) {
     furi_assert(context);
 
@@ -77,6 +94,7 @@ static int32_t nfc_magic_scanner_worker(void* context) {
             if(instance->current_protocol == NfcMagicProtocolGen1) {
                 instance->magic_protocol_detected = gen1a_poller_detect(instance->nfc);
                 if(instance->magic_protocol_detected) {
+                    instance->gen1_uid_len = nfc_magic_scanner_read_uid_len(instance->nfc);
                     break;
                 }
             } else if(instance->current_protocol == NfcMagicProtocolGen4) {
@@ -112,6 +130,7 @@ static int32_t nfc_magic_scanner_worker(void* context) {
                 .type = NfcMagicScannerEventTypeDetected,
                 .data.protocol = instance->current_protocol,
                 .data.gen2_type = instance->gen2_type,
+                .data.gen1_uid_len = instance->gen1_uid_len,
             };
             instance->callback(event, instance->context);
             break;

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.c
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.c
@@ -22,6 +22,7 @@ struct NfcMagicScanner {
 
     Gen4Password gen4_password;
     Gen4* gen4_data;
+    Gen2Type gen2_type;
     bool magic_protocol_detected;
 
     NfcMagicScannerCallback callback;
@@ -39,6 +40,7 @@ static const NfcProtocol nfc_magic_scanner_not_magic_protocols[] = {
 static void nfc_magic_scanner_reset(NfcMagicScanner* instance) {
     instance->session_state = NfcMagicScannerSessionStateIdle;
     instance->current_protocol = NfcMagicProtocolGen1;
+    instance->gen2_type = Gen2TypeUnknown;
 }
 
 NfcMagicScanner* nfc_magic_scanner_alloc(Nfc* nfc) {
@@ -88,9 +90,11 @@ static int32_t nfc_magic_scanner_worker(void* context) {
                     break;
                 }
             } else if(instance->current_protocol == NfcMagicProtocolGen2) {
-                Gen2PollerError error = gen2_poller_detect(instance->nfc);
+                Gen2Type gen2_type = Gen2TypeUnknown;
+                Gen2PollerError error = gen2_poller_detect_type(instance->nfc, &gen2_type);
                 instance->magic_protocol_detected = (error == Gen2PollerErrorNone);
                 if(instance->magic_protocol_detected) {
+                    instance->gen2_type = gen2_type;
                     break;
                 }
             } else if(instance->current_protocol == NfcMagicProtocolClassic) {
@@ -107,6 +111,7 @@ static int32_t nfc_magic_scanner_worker(void* context) {
             NfcMagicScannerEvent event = {
                 .type = NfcMagicScannerEventTypeDetected,
                 .data.protocol = instance->current_protocol,
+                .data.gen2_type = instance->gen2_type,
             };
             instance->callback(event, instance->context);
             break;

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.c
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.c
@@ -10,6 +10,8 @@
 
 #include <furi/furi.h>
 
+#define TAG "NfcMagicScanner"
+
 typedef enum {
     NfcMagicScannerSessionStateIdle,
     NfcMagicScannerSessionStateActive,
@@ -78,6 +80,15 @@ static uint8_t nfc_magic_scanner_read_uid_len(Nfc* nfc) {
     if(nfc_poller_detect(poller)) {
         const Iso14443_3aData* data = nfc_poller_get_data(poller);
         uid_len = data->uid_len;
+        if(uid_len != 4 && uid_len != 7) {
+            // Not a Gen1-relevant length (e.g. 10-byte or garbage): treat as unknown.
+            FURI_LOG_E(TAG, "Unexpected Gen1 UID length %u", (unsigned)uid_len);
+            uid_len = 0;
+        }
+    } else {
+        // Backdoor responded but standard activation failed (card moved?). Length stays
+        // 0 ("unknown") and callers fall back to 4-byte / skip the length check.
+        FURI_LOG_E(TAG, "Gen1 detected but UID-length activation failed");
     }
     nfc_poller_free(poller);
     return uid_len;

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.h
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.h
@@ -3,6 +3,7 @@
 #include "protocols/gen4/gen4.h"
 #include <nfc/nfc.h>
 #include "protocols/nfc_magic_protocols.h"
+#include "protocols/gen2/gen2_poller.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +17,7 @@ typedef enum {
 
 typedef struct {
     NfcMagicProtocol protocol;
+    Gen2Type gen2_type; // Valid when protocol == NfcMagicProtocolGen2
 } NfcMagicScannerEventData;
 
 typedef struct {

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.h
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.h
@@ -18,6 +18,7 @@ typedef enum {
 typedef struct {
     NfcMagicProtocol protocol;
     Gen2Type gen2_type; // Valid when protocol == NfcMagicProtocolGen2
+    uint8_t gen1_uid_len; // UID length (4/7) when protocol == NfcMagicProtocolGen1, else 0
 } NfcMagicScannerEventData;
 
 typedef struct {

--- a/base_pack/nfc_magic/magic/nfc_magic_scanner.h
+++ b/base_pack/nfc_magic/magic/nfc_magic_scanner.h
@@ -18,7 +18,7 @@ typedef enum {
 typedef struct {
     NfcMagicProtocol protocol;
     Gen2Type gen2_type; // Valid when protocol == NfcMagicProtocolGen2
-    uint8_t gen1_uid_len; // UID length (4/7) when protocol == NfcMagicProtocolGen1, else 0
+    uint8_t gen1_uid_len; // Gen1 UID length (4/7) when resolved; 0 if unknown or not Gen1
 } NfcMagicScannerEventData;
 
 typedef struct {

--- a/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.c
@@ -40,6 +40,7 @@ Gen1aPoller* gen1a_poller_alloc(Nfc* nfc) {
 
     Gen1aPoller* instance = malloc(sizeof(Gen1aPoller));
     instance->nfc = nfc;
+    instance->uid_len = 4;
 
     nfc_config(instance->nfc, NfcModePoller, NfcTechIso14443a);
     nfc_set_guard_time_us(instance->nfc, ISO14443_3A_GUARD_TIME_US);
@@ -65,6 +66,12 @@ void gen1a_poller_free(Gen1aPoller* instance) {
     nfc_device_free(instance->mfc_device);
 
     free(instance);
+}
+
+void gen1a_poller_set_uid_len(Gen1aPoller* instance, uint8_t uid_len) {
+    furi_assert(instance);
+    // Only 4- and 7-byte UIDs are valid; anything else (e.g. undetected) falls back to 4.
+    instance->uid_len = (uid_len == 7) ? 7 : 4;
 }
 
 NfcCommand gen1a_poller_detect_callback(NfcEvent event, void* context) {
@@ -125,9 +132,23 @@ bool gen1a_poller_detect(Nfc* nfc) {
     return gen1a_poller_detect_ctx.detected;
 }
 
+static void gen1a_poller_wipe_block0(MfClassicBlock* block, uint8_t uid_len) {
+    // Wipe to an all-zero UID matching the tag's UID length, keeping the generated
+    // SAK/ATQA/manufacturer bytes. The 4-byte layout carries a BCC at byte 4 (XOR of
+    // the UID bytes); the 7-byte layout has no BCC byte in block 0.
+    if(uid_len == 7) {
+        memset(block->data, 0x00, 7);
+    } else {
+        memset(block->data, 0x00, 4);
+        block->data[4] = block->data[0] ^ block->data[1] ^ block->data[2] ^ block->data[3];
+    }
+}
+
 static void gen1a_poller_reset(Gen1aPoller* instance) {
     instance->current_block = 0;
-    nfc_data_generator_fill_data(NfcDataGeneratorTypeMfClassic1k_4b, instance->mfc_device);
+    NfcDataGeneratorType type = (instance->uid_len == 7) ? NfcDataGeneratorTypeMfClassic1k_7b :
+                                                           NfcDataGeneratorTypeMfClassic1k_4b;
+    nfc_data_generator_fill_data(type, instance->mfc_device);
 }
 
 NfcCommand gen1a_poller_idle_handler(Gen1aPoller* instance) {
@@ -172,15 +193,22 @@ NfcCommand gen1a_poller_wipe_handler(Gen1aPoller* instance) {
         instance->state = Gen1aPollerStateSuccess;
     } else {
         do {
+            const MfClassicBlock* block_to_write = &mfc_data->block[instance->current_block];
+            MfClassicBlock block0;
+
             if(instance->current_block == 0) {
                 error = gen1a_poller_data_access(instance);
                 if(error != Gen1aPollerErrorNone) {
                     instance->state = Gen1aPollerStateFail;
                     break;
                 }
+                // Block 0 carries the UID: write an all-zero UID for this tag's length.
+                block0 = mfc_data->block[0];
+                gen1a_poller_wipe_block0(&block0, instance->uid_len);
+                block_to_write = &block0;
             }
-            error = gen1a_poller_write_block(
-                instance, instance->current_block, &mfc_data->block[instance->current_block]);
+
+            error = gen1a_poller_write_block(instance, instance->current_block, block_to_write);
             if(error != Gen1aPollerErrorNone) {
                 instance->state = Gen1aPollerStateFail;
                 break;

--- a/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.c
@@ -132,23 +132,20 @@ bool gen1a_poller_detect(Nfc* nfc) {
     return gen1a_poller_detect_ctx.detected;
 }
 
-static void gen1a_poller_wipe_block0(MfClassicBlock* block, uint8_t uid_len) {
-    // Wipe to an all-zero UID matching the tag's UID length, keeping the generated
-    // SAK/ATQA/manufacturer bytes. The 4-byte layout carries a BCC at byte 4 (XOR of
-    // the UID bytes); the 7-byte layout has no BCC byte in block 0.
-    if(uid_len == 7) {
-        memset(block->data, 0x00, 7);
-    } else {
-        memset(block->data, 0x00, 4);
-        block->data[4] = block->data[0] ^ block->data[1] ^ block->data[2] ^ block->data[3];
-    }
-}
-
 static void gen1a_poller_reset(Gen1aPoller* instance) {
     instance->current_block = 0;
+
     NfcDataGeneratorType type = (instance->uid_len == 7) ? NfcDataGeneratorTypeMfClassic1k_7b :
                                                            NfcDataGeneratorTypeMfClassic1k_4b;
     nfc_data_generator_fill_data(type, instance->mfc_device);
+
+    // Wipe to an all-zero UID of the tag's length, keeping the generated SAK/ATQA.
+    // mf_classic_set_uid writes the zeroed UID into block 0 plus the correct BCC for the
+    // 4-byte layout (the 7-byte layout has no block-0 BCC).
+    const uint8_t zero_uid[7] = {0};
+    MfClassicData* mfc_data =
+        (MfClassicData*)nfc_device_get_data(instance->mfc_device, NfcProtocolMfClassic);
+    mf_classic_set_uid(mfc_data, zero_uid, (instance->uid_len == 7) ? 7 : 4);
 }
 
 NfcCommand gen1a_poller_idle_handler(Gen1aPoller* instance) {
@@ -193,22 +190,15 @@ NfcCommand gen1a_poller_wipe_handler(Gen1aPoller* instance) {
         instance->state = Gen1aPollerStateSuccess;
     } else {
         do {
-            const MfClassicBlock* block_to_write = &mfc_data->block[instance->current_block];
-            MfClassicBlock block0;
-
             if(instance->current_block == 0) {
                 error = gen1a_poller_data_access(instance);
                 if(error != Gen1aPollerErrorNone) {
                     instance->state = Gen1aPollerStateFail;
                     break;
                 }
-                // Block 0 carries the UID: write an all-zero UID for this tag's length.
-                block0 = mfc_data->block[0];
-                gen1a_poller_wipe_block0(&block0, instance->uid_len);
-                block_to_write = &block0;
             }
-
-            error = gen1a_poller_write_block(instance, instance->current_block, block_to_write);
+            error = gen1a_poller_write_block(
+                instance, instance->current_block, &mfc_data->block[instance->current_block]);
             if(error != Gen1aPollerErrorNone) {
                 instance->state = Gen1aPollerStateFail;
                 break;

--- a/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller.h
@@ -55,6 +55,10 @@ bool gen1a_poller_detect(Nfc* nfc);
 
 Gen1aPoller* gen1a_poller_alloc(Nfc* nfc);
 
+// Sets the target UID length (4 or 7) for wipe: controls the block-0 layout and the
+// all-zero UID written. Values other than 7 are treated as 4.
+void gen1a_poller_set_uid_len(Gen1aPoller* instance, uint8_t uid_len);
+
 void gen1a_poller_free(Gen1aPoller* instance);
 
 void gen1a_poller_start(Gen1aPoller* instance, Gen1aPollerCallback callback, void* context);

--- a/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller_i.h
+++ b/base_pack/nfc_magic/magic/protocols/gen1a/gen1a_poller_i.h
@@ -45,6 +45,7 @@ struct Gen1aPoller {
     Gen1aPollerSessionState session_state;
 
     uint16_t current_block;
+    uint8_t uid_len; // Target UID length (4 or 7); selects the wipe block-0 layout
     NfcDevice* mfc_device;
 
     BitBuffer* tx_buffer;

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -256,10 +256,14 @@ static NfcCommand gen2_poller_cuid_probe_callback(NfcGenericEvent event, void* c
     if(iso3_event->type == Iso14443_3aPollerEventTypeReady) {
         Gen2PollerError error = gen2_poller_auth(instance, 0, &ctx->key, ctx->key_type, NULL);
         if(error == Gen2PollerErrorNone) {
-            gen2_poller_probe_block0_writable(instance, &ctx->cuid_writable);
-            // The probe only sends the first write phase. The card is now awaiting
-            // the data phase, so we deliberately send nothing more and return Stop
-            // below to drop the field — block 0 is never written.
+            // The probe sends only the first write phase and reads the ACK/NAK.
+            // We never send the data phase: returning Stop below drops the field,
+            // so block 0 cannot be written whether the card ACKed or NAKed.
+            Gen2PollerError probe_error =
+                gen2_poller_probe_block0_writable(instance, &ctx->cuid_writable);
+            if(probe_error != Gen2PollerErrorNone) {
+                FURI_LOG_D(TAG, "Block 0 write probe did not complete: %d", probe_error);
+            }
         }
     }
 
@@ -337,6 +341,13 @@ static bool gen2_poller_probe_static_nonce(Gen2Poller* instance) {
     // across fresh activations is effectively impossible, so any repeat means the
     // card emits a static nonce.
     if(valid < 2) {
+        // Inconclusive (card removed / unstable RF): report not-static, but log it
+        // so a missed static-nonce classification can be diagnosed.
+        FURI_LOG_D(
+            TAG,
+            "Static-nonce check inconclusive: %u/%u valid samples",
+            (unsigned)valid,
+            GEN2_STATIC_NONCE_SAMPLES);
         return false;
     }
     for(size_t i = 0; i < valid; i++) {

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -386,17 +386,17 @@ Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type) {
     return (*type != Gen2TypeUnknown) ? Gen2PollerErrorNone : Gen2PollerErrorNotPresent;
 }
 
-const char* gen2_type_get_name(Gen2Type type) {
+const char* gen2_type_get_detail(Gen2Type type) {
     switch(type) {
     case Gen2TypeCuid:
-        return "Gen2: CUID";
+        return "CUID";
     case Gen2TypeCuidStaticNonce:
-        return "Gen2: CUID. Static nonce";
+        return "CUID. Static nonce";
     case Gen2TypeAts:
-        return "Gen2: CUID. ATS";
+        return "CUID. ATS";
     case Gen2TypeUnknown:
     default:
-        return "Gen2";
+        return NULL;
     }
 }
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -293,28 +293,34 @@ static NfcCommand gen2_poller_nt_probe_callback(NfcGenericEvent event, void* con
     return NfcCommandStop;
 }
 
-// Runs one short poller session (a single card activation), so each call starts
-// from a fresh RF field — the reset that static-nonce detection relies on.
+// Runs one detection session in its own freshly-allocated Gen2Poller, so each call
+// starts from a fresh RF field (the reset static-nonce detection relies on). A fresh
+// poller per session is mandatory, not just convenient: an NfcPoller can be started
+// only once. Stopping a session resets the shared Nfc config_state to Idle, and only
+// nfc_poller_alloc (via iso14443_3a_poller_alloc -> nfc_config) sets it back to Done,
+// so restarting the same poller would trip nfc_start's config_state check.
 static void gen2_poller_run_detect_session(
-    Gen2Poller* instance,
+    Nfc* nfc,
     NfcGenericCallback callback,
     Gen2DetectContext* ctx) {
+    ctx->poller = gen2_poller_alloc(nfc);
     ctx->thread_id = furi_thread_get_current_id();
-    nfc_poller_start(instance->poller, callback, ctx);
+    nfc_poller_start(ctx->poller->poller, callback, ctx);
     furi_thread_flags_wait(GEN2_POLLER_THREAD_FLAG_DETECTED, FuriFlagWaitAny, FuriWaitForever);
     furi_thread_flags_clear(GEN2_POLLER_THREAD_FLAG_DETECTED);
-    nfc_poller_stop(instance->poller);
+    nfc_poller_stop(ctx->poller->poller);
+    gen2_poller_free(ctx->poller);
+    ctx->poller = NULL;
 }
 
-static bool gen2_poller_probe_cuid(Gen2Poller* instance) {
+static bool gen2_poller_probe_cuid(Nfc* nfc) {
     for(size_t i = 0; i < COUNT_OF(gen2_cuid_probe_keys); i++) {
         Gen2DetectContext ctx = {
-            .poller = instance,
             .key = gen2_cuid_probe_keys[i].key,
             .key_type = gen2_cuid_probe_keys[i].key_type,
             .cuid_writable = false,
         };
-        gen2_poller_run_detect_session(instance, gen2_poller_cuid_probe_callback, &ctx);
+        gen2_poller_run_detect_session(nfc, gen2_poller_cuid_probe_callback, &ctx);
         if(ctx.cuid_writable) {
             return true;
         }
@@ -322,16 +328,15 @@ static bool gen2_poller_probe_cuid(Gen2Poller* instance) {
     return false;
 }
 
-static bool gen2_poller_probe_static_nonce(Gen2Poller* instance) {
+static bool gen2_poller_probe_static_nonce(Nfc* nfc) {
     MfClassicNt nonces[GEN2_STATIC_NONCE_SAMPLES];
     size_t valid = 0;
 
     for(size_t i = 0; i < GEN2_STATIC_NONCE_SAMPLES; i++) {
         Gen2DetectContext ctx = {
-            .poller = instance,
             .nt_valid = false,
         };
-        gen2_poller_run_detect_session(instance, gen2_poller_nt_probe_callback, &ctx);
+        gen2_poller_run_detect_session(nfc, gen2_poller_nt_probe_callback, &ctx);
         if(ctx.nt_valid) {
             nonces[valid++] = ctx.nt;
         }
@@ -372,12 +377,11 @@ Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type) {
         return Gen2PollerErrorNone;
     }
 
-    // 2. Behavioural CUID confirmation, then static-nonce classification.
-    Gen2Poller* instance = gen2_poller_alloc(nfc);
-    if(gen2_poller_probe_cuid(instance)) {
-        *type = gen2_poller_probe_static_nonce(instance) ? Gen2TypeCuidStaticNonce : Gen2TypeCuid;
+    // 2. Behavioural CUID confirmation, then static-nonce classification. Each probe
+    // runs in its own poller session (allocated per session in run_detect_session).
+    if(gen2_poller_probe_cuid(nfc)) {
+        *type = gen2_poller_probe_static_nonce(nfc) ? Gen2TypeCuidStaticNonce : Gen2TypeCuid;
     }
-    gen2_poller_free(instance);
 
     return (*type != Gen2TypeUnknown) ? Gen2PollerErrorNone : Gen2PollerErrorNotPresent;
 }

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -216,6 +216,174 @@ Gen2PollerError gen2_poller_detect(Nfc* nfc) {
     return detect_ctx.error;
 }
 
+// --- Gen2 sub-type classification (CUID write probe + static-nonce detection) ---
+
+#define GEN2_STATIC_NONCE_SAMPLES (3)
+
+// Default sector-0 keys tried for the CUID write probe. Blank/fresh magic cards
+// (and blank normal cards) use FF..FF; matching Proxmark3 we try B then A.
+typedef struct {
+    MfClassicKeyType key_type;
+    MfClassicKey key;
+} Gen2ProbeKey;
+
+static const Gen2ProbeKey gen2_cuid_probe_keys[] = {
+    {MfClassicKeyTypeB, {.data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}}},
+    {MfClassicKeyTypeA, {.data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}}},
+};
+
+typedef struct {
+    Gen2Poller* poller;
+    FuriThreadId thread_id;
+    MfClassicKey key;
+    MfClassicKeyType key_type;
+    bool cuid_writable;
+    MfClassicNt nt;
+    bool nt_valid;
+} Gen2DetectContext;
+
+static NfcCommand gen2_poller_cuid_probe_callback(NfcGenericEvent event, void* context) {
+    furi_assert(context);
+    furi_assert(event.event_data);
+    furi_assert(event.instance);
+
+    Gen2DetectContext* ctx = context;
+    Gen2Poller* instance = ctx->poller;
+    Iso14443_3aPollerEvent* iso3_event = event.event_data;
+    instance->iso3_poller = event.instance;
+    instance->auth_state = Gen2AuthStateIdle;
+
+    if(iso3_event->type == Iso14443_3aPollerEventTypeReady) {
+        Gen2PollerError error = gen2_poller_auth(instance, 0, &ctx->key, ctx->key_type, NULL);
+        if(error == Gen2PollerErrorNone) {
+            gen2_poller_probe_block0_writable(instance, &ctx->cuid_writable);
+            // The probe only sends the first write phase. The card is now awaiting
+            // the data phase, so we deliberately send nothing more and return Stop
+            // below to drop the field — block 0 is never written.
+        }
+    }
+
+    furi_thread_flags_set(ctx->thread_id, GEN2_POLLER_THREAD_FLAG_DETECTED);
+    return NfcCommandStop;
+}
+
+static NfcCommand gen2_poller_nt_probe_callback(NfcGenericEvent event, void* context) {
+    furi_assert(context);
+    furi_assert(event.event_data);
+    furi_assert(event.instance);
+
+    Gen2DetectContext* ctx = context;
+    Gen2Poller* instance = ctx->poller;
+    Iso14443_3aPollerEvent* iso3_event = event.event_data;
+    instance->iso3_poller = event.instance;
+    ctx->nt_valid = false;
+
+    if(iso3_event->type == Iso14443_3aPollerEventTypeReady) {
+        // Plain auth step 1 only: read the tag nonce, never complete the handshake.
+        // No key needed.
+        Gen2PollerError error = gen2_poller_get_nt(instance, 0, MfClassicKeyTypeA, &ctx->nt);
+        ctx->nt_valid = (error == Gen2PollerErrorNone);
+    }
+
+    furi_thread_flags_set(ctx->thread_id, GEN2_POLLER_THREAD_FLAG_DETECTED);
+    return NfcCommandStop;
+}
+
+// Runs one short poller session (a single card activation), so each call starts
+// from a fresh RF field — the reset that static-nonce detection relies on.
+static void gen2_poller_run_detect_session(
+    Gen2Poller* instance,
+    NfcGenericCallback callback,
+    Gen2DetectContext* ctx) {
+    ctx->thread_id = furi_thread_get_current_id();
+    nfc_poller_start(instance->poller, callback, ctx);
+    furi_thread_flags_wait(GEN2_POLLER_THREAD_FLAG_DETECTED, FuriFlagWaitAny, FuriWaitForever);
+    furi_thread_flags_clear(GEN2_POLLER_THREAD_FLAG_DETECTED);
+    nfc_poller_stop(instance->poller);
+}
+
+static bool gen2_poller_probe_cuid(Gen2Poller* instance) {
+    for(size_t i = 0; i < COUNT_OF(gen2_cuid_probe_keys); i++) {
+        Gen2DetectContext ctx = {
+            .poller = instance,
+            .key = gen2_cuid_probe_keys[i].key,
+            .key_type = gen2_cuid_probe_keys[i].key_type,
+            .cuid_writable = false,
+        };
+        gen2_poller_run_detect_session(instance, gen2_poller_cuid_probe_callback, &ctx);
+        if(ctx.cuid_writable) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool gen2_poller_probe_static_nonce(Gen2Poller* instance) {
+    MfClassicNt nonces[GEN2_STATIC_NONCE_SAMPLES];
+    size_t valid = 0;
+
+    for(size_t i = 0; i < GEN2_STATIC_NONCE_SAMPLES; i++) {
+        Gen2DetectContext ctx = {
+            .poller = instance,
+            .nt_valid = false,
+        };
+        gen2_poller_run_detect_session(instance, gen2_poller_nt_probe_callback, &ctx);
+        if(ctx.nt_valid) {
+            nonces[valid++] = ctx.nt;
+        }
+    }
+
+    // Need at least two readings to decide. A 32-bit random/PRNG nonce repeating
+    // across fresh activations is effectively impossible, so any repeat means the
+    // card emits a static nonce.
+    if(valid < 2) {
+        return false;
+    }
+    for(size_t i = 0; i < valid; i++) {
+        for(size_t j = i + 1; j < valid; j++) {
+            if(memcmp(nonces[i].data, nonces[j].data, sizeof(MfClassicNt)) == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type) {
+    furi_assert(nfc);
+    furi_assert(type);
+
+    *type = Gen2TypeUnknown;
+
+    // 1. Known-ATS fingerprint: cheap, no auth, identifies a recognisable subset.
+    if(gen2_poller_detect(nfc) == Gen2PollerErrorNone) {
+        *type = Gen2TypeAts;
+        return Gen2PollerErrorNone;
+    }
+
+    // 2. Behavioural CUID confirmation, then static-nonce classification.
+    Gen2Poller* instance = gen2_poller_alloc(nfc);
+    if(gen2_poller_probe_cuid(instance)) {
+        *type = gen2_poller_probe_static_nonce(instance) ? Gen2TypeCuidStaticNonce : Gen2TypeCuid;
+    }
+    gen2_poller_free(instance);
+
+    return (*type != Gen2TypeUnknown) ? Gen2PollerErrorNone : Gen2PollerErrorNotPresent;
+}
+
+const char* gen2_type_get_name(Gen2Type type) {
+    switch(type) {
+    case Gen2TypeCuid:
+        return "Gen2: CUID";
+    case Gen2TypeCuidStaticNonce:
+        return "Gen2: CUID Static Nonce (MF-3.2)";
+    case Gen2TypeAts:
+    case Gen2TypeUnknown:
+    default:
+        return "Gen2";
+    }
+}
+
 NfcCommand gen2_poller_idle_handler(Gen2Poller* instance) {
     furi_assert(instance);
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -96,7 +96,7 @@ const char* const gen2_problem_strings[] = {
     "The selected file is incomplete",
 };
 
-Gen2Poller* gen2_poller_alloc(Nfc* nfc) {
+static Gen2Poller* gen2_poller_alloc_internal(Nfc* nfc, bool with_write_ctx) {
     Gen2Poller* instance = malloc(sizeof(Gen2Poller));
     instance->poller = nfc_poller_alloc(nfc, NfcProtocolIso14443_3a);
     instance->data = mf_classic_alloc();
@@ -109,12 +109,24 @@ Gen2Poller* gen2_poller_alloc(Nfc* nfc) {
 
     instance->gen2_event.data = &instance->gen2_event_data;
 
-    instance->mode_ctx.write_ctx.mfc_data_source = malloc(sizeof(MfClassicData));
-    instance->mode_ctx.write_ctx.mfc_data_target = malloc(sizeof(MfClassicData));
+    // The two ~4 KB write/wipe data buffers are only used by the write path. Detection
+    // sessions skip them and leave the pointers NULL (gen2_poller_free's free(NULL) is
+    // a no-op), since gen2_poller_alloc runs up to 5 times per detection.
+    if(with_write_ctx) {
+        instance->mode_ctx.write_ctx.mfc_data_source = malloc(sizeof(MfClassicData));
+        instance->mode_ctx.write_ctx.mfc_data_target = malloc(sizeof(MfClassicData));
+    } else {
+        instance->mode_ctx.write_ctx.mfc_data_source = NULL;
+        instance->mode_ctx.write_ctx.mfc_data_target = NULL;
+    }
 
     instance->mode_ctx.write_ctx.need_halt_before_write = true;
 
     return instance;
+}
+
+Gen2Poller* gen2_poller_alloc(Nfc* nfc) {
+    return gen2_poller_alloc_internal(nfc, true);
 }
 
 void gen2_poller_free(Gen2Poller* instance) {
@@ -303,7 +315,7 @@ static void gen2_poller_run_detect_session(
     Nfc* nfc,
     NfcGenericCallback callback,
     Gen2DetectContext* ctx) {
-    ctx->poller = gen2_poller_alloc(nfc);
+    ctx->poller = gen2_poller_alloc_internal(nfc, false);
     ctx->thread_id = furi_thread_get_current_id();
     nfc_poller_start(ctx->poller->poller, callback, ctx);
     furi_thread_flags_wait(GEN2_POLLER_THREAD_FLAG_DETECTED, FuriFlagWaitAny, FuriWaitForever);

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.c
@@ -391,8 +391,9 @@ const char* gen2_type_get_name(Gen2Type type) {
     case Gen2TypeCuid:
         return "Gen2: CUID";
     case Gen2TypeCuidStaticNonce:
-        return "Gen2: CUID Static Nonce (MF-3.2)";
+        return "Gen2: CUID. Static nonce";
     case Gen2TypeAts:
+        return "Gen2: CUID. ATS";
     case Gen2TypeUnknown:
     default:
         return "Gen2";

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
@@ -23,7 +23,8 @@ typedef enum {
 // Gen2 sub-classification, refined from coarse to specific.
 typedef enum {
     Gen2TypeUnknown, // Not a Gen2 card, or Gen2 not yet classified
-    Gen2TypeAts, // Recognised by a known magic ATS fingerprint
+    Gen2TypeAts, // Matched a known magic-CUID ATS fingerprint; these products are
+                 // known to be CUID, so the write probe is skipped ("CUID. ATS")
     Gen2TypeCuid, // Block 0 directly writable (CUID), confirmed by write probe
     Gen2TypeCuidStaticNonce, // CUID that also returns a static (non-random) nonce
 } Gen2Type;

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
@@ -22,7 +22,7 @@ typedef enum {
 
 // Gen2 sub-classification, refined from coarse to specific.
 typedef enum {
-    Gen2TypeUnknown, // Not a Gen2 card
+    Gen2TypeUnknown, // Not a Gen2 card, or Gen2 not yet classified
     Gen2TypeAts, // Recognised by a known magic ATS fingerprint
     Gen2TypeCuid, // Block 0 directly writable (CUID), confirmed by write probe
     Gen2TypeCuidStaticNonce, // CUID that also returns a static (non-random) nonce

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
@@ -92,8 +92,9 @@ Gen2PollerError gen2_poller_detect(Nfc* nfc);
 // CUID with static nonce). Returns Gen2PollerErrorNone when any Gen2 type is found.
 Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type);
 
-// Human-readable label for a Gen2 sub-type (e.g. "Gen2: CUID").
-const char* gen2_type_get_name(Gen2Type type);
+// Gen2 sub-type detail shown under the "Gen 2" type line (e.g. "CUID. Static nonce"),
+// or NULL if none.
+const char* gen2_type_get_detail(Gen2Type type);
 
 Gen2Poller* gen2_poller_alloc(Nfc* nfc);
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller.h
@@ -20,6 +20,14 @@ typedef enum {
     Gen2PollerErrorAccess,
 } Gen2PollerError;
 
+// Gen2 sub-classification, refined from coarse to specific.
+typedef enum {
+    Gen2TypeUnknown, // Not a Gen2 card
+    Gen2TypeAts, // Recognised by a known magic ATS fingerprint
+    Gen2TypeCuid, // Block 0 directly writable (CUID), confirmed by write probe
+    Gen2TypeCuidStaticNonce, // CUID that also returns a static (non-random) nonce
+} Gen2Type;
+
 // Possible write problems, sorted by priority top to bottom
 typedef union {
     uint8_t all_problems;
@@ -79,6 +87,13 @@ typedef NfcCommand (*Gen2PollerCallback)(Gen2PollerEvent event, void* context);
 typedef struct Gen2Poller Gen2Poller;
 
 Gen2PollerError gen2_poller_detect(Nfc* nfc);
+
+// Detects whether the card is Gen2 and classifies its sub-type (ATS / CUID /
+// CUID with static nonce). Returns Gen2PollerErrorNone when any Gen2 type is found.
+Gen2PollerError gen2_poller_detect_type(Nfc* nfc, Gen2Type* type);
+
+// Human-readable label for a Gen2 sub-type (e.g. "Gen2: CUID").
+const char* gen2_type_get_name(Gen2Type type);
 
 Gen2Poller* gen2_poller_alloc(Nfc* nfc);
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.c
@@ -118,8 +118,13 @@ static Gen2PollerError gen2_poller_get_nt_common(
                 instance->tx_plain_buffer,
                 instance->rx_plain_buffer,
                 GEN2_POLLER_MAX_FWT);
+            // A bare tag nonce carries no CRC, so WrongCrc is the expected
+            // "success" here. Anything else - including a CRC-valid (None) frame,
+            // which is not a nonce - means no nonce was read; report it as an error
+            // so callers never treat an unwritten nt as valid.
             if(error != Iso14443_3aErrorWrongCrc) {
-                ret = mf_classic_process_error(error);
+                ret = (error == Iso14443_3aErrorNone) ? MfClassicErrorProtocol :
+                                                        mf_classic_process_error(error);
                 break;
             }
         }

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.c
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.c
@@ -343,6 +343,50 @@ Gen2PollerError
     return ret;
 }
 
+Gen2PollerError gen2_poller_probe_block0_writable(Gen2Poller* instance, bool* writable) {
+    furi_assert(instance);
+    furi_assert(writable);
+
+    Gen2PollerError ret = Gen2PollerErrorNone;
+    Iso14443_3aError error = Iso14443_3aErrorNone;
+    *writable = false;
+
+    // Non-destructive CUID probe: this sends ONLY the first phase of the two-phase
+    // MIFARE write to block 0. A directly-writable block 0 (Gen2/CUID) ACKs it, while
+    // a normal Classic NAKs its read-only manufacturer block. The 16-byte data phase is
+    // never transmitted, so block 0 is never modified. The caller MUST drop the field
+    // immediately afterwards (do not send any further frame) so nothing can be written.
+    do {
+        uint8_t write_block_cmd[2] = {MF_CLASSIC_CMD_WRITE_BLOCK, 0};
+        bit_buffer_copy_bytes(instance->tx_plain_buffer, write_block_cmd, sizeof(write_block_cmd));
+        iso14443_crc_append(Iso14443CrcTypeA, instance->tx_plain_buffer);
+
+        crypto1_encrypt(
+            instance->crypto, NULL, instance->tx_plain_buffer, instance->tx_encrypted_buffer);
+
+        error = iso14443_3a_poller_txrx_custom_parity(
+            instance->iso3_poller,
+            instance->tx_encrypted_buffer,
+            instance->rx_encrypted_buffer,
+            GEN2_POLLER_MAX_FWT);
+        if(error != Iso14443_3aErrorNone) {
+            ret = gen2_poller_process_iso3_error(error);
+            break;
+        }
+        if(bit_buffer_get_size(instance->rx_encrypted_buffer) != 4) {
+            ret = Gen2PollerErrorProtocol;
+            break;
+        }
+
+        crypto1_decrypt(
+            instance->crypto, instance->rx_encrypted_buffer, instance->rx_plain_buffer);
+
+        *writable = (bit_buffer_get_byte(instance->rx_plain_buffer, 0) == MF_CLASSIC_CMD_ACK);
+    } while(false);
+
+    return ret;
+}
+
 bool gen2_poller_can_write_block(const MfClassicData* target_data, uint8_t block_num) {
     furi_assert(target_data);
 

--- a/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.h
+++ b/base_pack/nfc_magic/magic/protocols/gen2/gen2_poller_i.h
@@ -112,6 +112,16 @@ Gen2PollerError gen2_poller_auth(
 
 Gen2PollerError gen2_poller_halt(Gen2Poller* instance);
 
+Gen2PollerError gen2_poller_get_nt(
+    Gen2Poller* instance,
+    uint8_t block_num,
+    MfClassicKeyType key_type,
+    MfClassicNt* nt);
+
+// Non-destructive probe: sends only the first phase of a write to block 0 and
+// reports whether the card ACKs it (block 0 directly writable => Gen2/CUID).
+Gen2PollerError gen2_poller_probe_block0_writable(Gen2Poller* instance, bool* writable);
+
 Gen2PollerError
     gen2_poller_write_block(Gen2Poller* instance, uint8_t block_num, const MfClassicBlock* data);
 

--- a/base_pack/nfc_magic/magic/protocols/nfc_magic_protocols.c
+++ b/base_pack/nfc_magic/magic/protocols/nfc_magic_protocols.c
@@ -3,10 +3,10 @@
 #include <furi/furi.h>
 
 static const char* nfc_magic_protocol_names[NfcMagicProtocolNum] = {
-    [NfcMagicProtocolGen1] = "Gen1A/B",
-    [NfcMagicProtocolGen2] = "Gen2",
+    [NfcMagicProtocolGen1] = "Gen 1A/B",
+    [NfcMagicProtocolGen2] = "Gen 2",
     [NfcMagicProtocolClassic] = "MIFARE Classic",
-    [NfcMagicProtocolGen4] = "Gen4 GTU",
+    [NfcMagicProtocolGen4] = "Gen 4 GTU",
 };
 
 const char* nfc_magic_protocols_get_name(NfcMagicProtocol protocol) {

--- a/base_pack/nfc_magic/magic/protocols/nfc_magic_protocols.h
+++ b/base_pack/nfc_magic/magic/protocols/nfc_magic_protocols.h
@@ -6,8 +6,12 @@ extern "C" {
 
 typedef enum {
     NfcMagicProtocolGen1,
-    NfcMagicProtocolGen2,
+    // Gen4 is probed before Gen2: a wiped/blank UMC (e.g. after
+    // `hf_mf_ultimatecard -w 0`) also satisfies the Gen2 CUID heuristic (default keys,
+    // writable block 0, static nonce), so its GTU backdoor must be checked first to
+    // classify it as Gen4 rather than as Gen2 CUID.
     NfcMagicProtocolGen4,
+    NfcMagicProtocolGen2,
     NfcMagicProtocolClassic, // Last to give priority to the others
 
     NfcMagicProtocolNum,

--- a/base_pack/nfc_magic/nfc_magic_app_i.h
+++ b/base_pack/nfc_magic/nfc_magic_app_i.h
@@ -110,6 +110,7 @@ struct NfcMagicApp {
     Nfc* nfc;
     NfcMagicProtocol protocol;
     Gen2Type gen2_type;
+    uint8_t gen1_uid_len;
     NfcMagicScanner* scanner;
     NfcPoller* poller;
     Gen1aPoller* gen1a_poller;

--- a/base_pack/nfc_magic/nfc_magic_app_i.h
+++ b/base_pack/nfc_magic/nfc_magic_app_i.h
@@ -111,6 +111,7 @@ struct NfcMagicApp {
     NfcMagicProtocol protocol;
     Gen2Type gen2_type;
     uint8_t gen1_uid_len;
+    bool source_uid_mismatch;
     NfcMagicScanner* scanner;
     NfcPoller* poller;
     Gen1aPoller* gen1a_poller;

--- a/base_pack/nfc_magic/nfc_magic_app_i.h
+++ b/base_pack/nfc_magic/nfc_magic_app_i.h
@@ -109,6 +109,7 @@ struct NfcMagicApp {
 
     Nfc* nfc;
     NfcMagicProtocol protocol;
+    Gen2Type gen2_type;
     NfcMagicScanner* scanner;
     NfcPoller* poller;
     Gen1aPoller* gen1a_poller;

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
@@ -8,6 +8,7 @@ void nfc_magic_check_worker_callback(NfcMagicScannerEvent event, void* context) 
     if(event.type == NfcMagicScannerEventTypeDetected) {
         instance->protocol = event.data.protocol;
         instance->gen2_type = event.data.gen2_type;
+        instance->gen1_uid_len = event.data.gen1_uid_len;
         view_dispatcher_send_custom_event(
             instance->view_dispatcher, NfcMagicCustomEventWorkerSuccess);
     } else if(event.type == NfcMagicScannerEventTypeDetectedNotMagic) {

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_check.c
@@ -7,6 +7,7 @@ void nfc_magic_check_worker_callback(NfcMagicScannerEvent event, void* context) 
 
     if(event.type == NfcMagicScannerEventTypeDetected) {
         instance->protocol = event.data.protocol;
+        instance->gen2_type = event.data.gen2_type;
         view_dispatcher_send_custom_event(
             instance->view_dispatcher, NfcMagicCustomEventWorkerSuccess);
     } else if(event.type == NfcMagicScannerEventTypeDetectedNotMagic) {

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_file_select.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_file_select.c
@@ -43,20 +43,36 @@ static bool nfc_magic_scene_file_select_is_file_suitable(NfcMagicApp* instance) 
     return suitable;
 }
 
+// For a detected Gen1 tag whose UID length is known, the source file's UID length
+// must match it: writing a mismatched block 0 would corrupt the UID/BCC. Returns true
+// (rejecting the file) on mismatch; allows it when the tag length is unknown.
+static bool nfc_magic_scene_file_select_is_uid_len_mismatch(NfcMagicApp* instance) {
+    if(instance->protocol != NfcMagicProtocolGen1) return false;
+    if(instance->gen1_uid_len == 0) return false;
+
+    size_t source_uid_len = 0;
+    nfc_device_get_uid(instance->source_dev, &source_uid_len);
+
+    return source_uid_len != instance->gen1_uid_len;
+}
+
 void nfc_magic_scene_file_select_on_enter(void* context) {
     NfcMagicApp* instance = context;
 
+    instance->source_uid_mismatch = false;
+
     if(nfc_magic_load_from_file_select(instance)) {
-        if(nfc_magic_scene_file_select_is_file_suitable(instance)) {
-            if(instance->protocol == NfcMagicProtocolClassic ||
-               instance->protocol == NfcMagicProtocolGen2) {
-                scene_manager_next_scene(
-                    instance->scene_manager, NfcMagicSceneMfClassicDictAttack);
-            } else {
-                scene_manager_next_scene(instance->scene_manager, NfcMagicSceneWriteConfirm);
-            }
-        } else {
+        if(!nfc_magic_scene_file_select_is_file_suitable(instance)) {
             scene_manager_next_scene(instance->scene_manager, NfcMagicSceneWrongCard);
+        } else if(nfc_magic_scene_file_select_is_uid_len_mismatch(instance)) {
+            instance->source_uid_mismatch = true;
+            scene_manager_next_scene(instance->scene_manager, NfcMagicSceneWrongCard);
+        } else if(
+            instance->protocol == NfcMagicProtocolClassic ||
+            instance->protocol == NfcMagicProtocolGen2) {
+            scene_manager_next_scene(instance->scene_manager, NfcMagicSceneMfClassicDictAttack);
+        } else {
+            scene_manager_next_scene(instance->scene_manager, NfcMagicSceneWriteConfirm);
         }
     } else {
         scene_manager_previous_scene(instance->scene_manager);

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_fail.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_fail.c
@@ -17,7 +17,7 @@ void nfc_magic_scene_gen4_fail_on_enter(void* context) {
     widget_add_string_element(
         widget, 7, 4, AlignLeft, AlignTop, FontPrimary, "Something gone wrong!");
     widget_add_string_multiline_element(
-        widget, 7, 17, AlignLeft, AlignTop, FontSecondary, "No response. Maybe\nnot Gen4 card?");
+        widget, 7, 17, AlignLeft, AlignTop, FontSecondary, "No response. Maybe\nnot Gen 4 card?");
 
     widget_add_button_element(
         widget, GuiButtonTypeLeft, "Back", nfc_magic_scene_gen4_fail_widget_callback, instance);

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_show_cfg.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_show_cfg.c
@@ -24,7 +24,7 @@ void nfc_magic_scene_gen4_show_cfg_on_enter(void* context) {
         furi_string_cat_printf(output, "%02X%02X ", config->data_raw[i], config->data_raw[i + 1]);
     }
 
-    widget_add_string_element(widget, 3, 4, AlignLeft, AlignTop, FontPrimary, "Gen4 Config");
+    widget_add_string_element(widget, 3, 4, AlignLeft, AlignTop, FontPrimary, "Gen 4 Config");
 
     widget_add_text_scroll_element(widget, 3, 17, 124, 50, furi_string_get_cstr(output));
 

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_show_info.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_gen4_show_info.c
@@ -27,7 +27,7 @@ void nfc_magic_scene_gen4_show_info_on_enter(void* context) {
 
     FuriString* output = furi_string_alloc();
 
-    furi_string_printf(output, "\e#Gen4\n");
+    furi_string_printf(output, "\e#Gen 4\n");
 
     // Revision
     furi_string_cat_printf(

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
@@ -28,8 +28,10 @@ void nfc_magic_scene_magic_info_on_enter(void* context) {
         widget_add_string_element(
             widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic card detected!");
     }
-    furi_string_cat_printf(
-        message, "Magic Type: %s", nfc_magic_protocols_get_name(instance->protocol));
+    const char* type_name = (instance->protocol == NfcMagicProtocolGen2) ?
+                                gen2_type_get_name(instance->gen2_type) :
+                                nfc_magic_protocols_get_name(instance->protocol);
+    furi_string_cat_printf(message, "Magic Type: %s", type_name);
     widget_add_text_box_element(
         widget, 0, 10, 128, 54, AlignLeft, AlignTop, furi_string_get_cstr(message), false);
 

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
@@ -32,11 +32,19 @@ void nfc_magic_scene_magic_info_on_enter(void* context) {
             widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic card detected!");
         furi_string_printf(
             message, "Magic Type: %s", nfc_magic_protocols_get_name(instance->protocol));
+
+        const char* detail = NULL;
         if(instance->protocol == NfcMagicProtocolGen2) {
-            const char* detail = gen2_type_get_detail(instance->gen2_type);
-            if(detail) {
-                furi_string_cat_printf(message, "\n%s", detail);
+            detail = gen2_type_get_detail(instance->gen2_type);
+        } else if(instance->protocol == NfcMagicProtocolGen1) {
+            if(instance->gen1_uid_len == 4) {
+                detail = "4-byte UID";
+            } else if(instance->gen1_uid_len == 7) {
+                detail = "7-byte UID";
             }
+        }
+        if(detail) {
+            furi_string_cat_printf(message, "\n%s", detail);
         }
     }
     widget_add_text_box_element(

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
@@ -23,16 +23,21 @@ void nfc_magic_scene_magic_info_on_enter(void* context) {
     if(instance->protocol == NfcMagicProtocolClassic) {
         widget_add_string_element(
             widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic Not Confirmed");
+        // Hand-wrapped: the text box breaks mid-word, so keep each line short.
         furi_string_printf(
             message,
-            "Not a magic tag, or sector 0 key is non-standard. Try writing to confirm.");
+            "Not a magic tag, or\nsector 0 key is non-standard.\nTry writing to confirm.");
     } else {
         widget_add_string_element(
             widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic card detected!");
-        const char* type_name = (instance->protocol == NfcMagicProtocolGen2) ?
-                                    gen2_type_get_name(instance->gen2_type) :
-                                    nfc_magic_protocols_get_name(instance->protocol);
-        furi_string_cat_printf(message, "Magic Type: %s", type_name);
+        furi_string_printf(
+            message, "Magic Type: %s", nfc_magic_protocols_get_name(instance->protocol));
+        if(instance->protocol == NfcMagicProtocolGen2) {
+            const char* detail = gen2_type_get_detail(instance->gen2_type);
+            if(detail) {
+                furi_string_cat_printf(message, "\n%s", detail);
+            }
+        }
     }
     widget_add_text_box_element(
         widget, 0, 10, 128, 54, AlignLeft, AlignTop, furi_string_get_cstr(message), false);

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_magic_info.c
@@ -22,16 +22,18 @@ void nfc_magic_scene_magic_info_on_enter(void* context) {
 
     if(instance->protocol == NfcMagicProtocolClassic) {
         widget_add_string_element(
-            widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "It Might Be a Magic Card");
-        furi_string_printf(message, "You can make sure the card is\nmagic by writing to it\n");
+            widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic Not Confirmed");
+        furi_string_printf(
+            message,
+            "Not a magic tag, or sector 0 key is non-standard. Try writing to confirm.");
     } else {
         widget_add_string_element(
             widget, 0, 0, AlignLeft, AlignTop, FontPrimary, "Magic card detected!");
+        const char* type_name = (instance->protocol == NfcMagicProtocolGen2) ?
+                                    gen2_type_get_name(instance->gen2_type) :
+                                    nfc_magic_protocols_get_name(instance->protocol);
+        furi_string_cat_printf(message, "Magic Type: %s", type_name);
     }
-    const char* type_name = (instance->protocol == NfcMagicProtocolGen2) ?
-                                gen2_type_get_name(instance->gen2_type) :
-                                nfc_magic_protocols_get_name(instance->protocol);
-    furi_string_cat_printf(message, "Magic Type: %s", type_name);
     widget_add_text_box_element(
         widget, 0, 10, 128, 54, AlignLeft, AlignTop, furi_string_get_cstr(message), false);
 

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_not_magic.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_not_magic.c
@@ -22,7 +22,7 @@ void nfc_magic_scene_not_magic_on_enter(void* context) {
         AlignLeft,
         AlignTop,
         FontSecondary,
-        "Not magic or unsupported\ncard. Only Gen1, Gen2 and \nGen4 UMC cards supported.");
+        "Not magic or unsupported\ncard. Only Gen 1, Gen 2 and\nGen 4 UMC cards supported.");
     widget_add_button_element(
         widget, GuiButtonTypeLeft, "Retry", nfc_magic_scene_not_magic_widget_callback, instance);
 

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_start.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_start.c
@@ -22,7 +22,7 @@ void nfc_magic_scene_start_on_enter(void* context) {
         instance);
     submenu_add_item(
         submenu,
-        "Gen4 Actions",
+        "Gen 4 Actions",
         SubmenuIndexGen4ActionsMenu,
         nfc_magic_scene_start_submenu_callback,
         instance);

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_wipe.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_wipe.c
@@ -108,6 +108,7 @@ void nfc_magic_scene_wipe_on_enter(void* context) {
 
     if(instance->protocol == NfcMagicProtocolGen1) {
         instance->gen1a_poller = gen1a_poller_alloc(instance->nfc);
+        gen1a_poller_set_uid_len(instance->gen1a_poller, instance->gen1_uid_len);
         gen1a_poller_start(
             instance->gen1a_poller, nfc_magic_scene_wipe_gen1_poller_callback, instance);
     } else if(instance->protocol == NfcMagicProtocolGen2) {

--- a/base_pack/nfc_magic/scenes/nfc_magic_scene_wrong_card.c
+++ b/base_pack/nfc_magic/scenes/nfc_magic_scene_wrong_card.c
@@ -16,17 +16,36 @@ void nfc_magic_scene_wrong_card_on_enter(void* context) {
 
     notification_message(instance->notifications, &sequence_error);
 
-    widget_add_icon_element(widget, 73, 17, &I_DolphinCommon_56x48);
-    widget_add_string_element(
-        widget, 1, 4, AlignLeft, AlignTop, FontPrimary, "This is wrong card");
-    widget_add_string_multiline_element(
-        widget,
-        1,
-        17,
-        AlignLeft,
-        AlignTop,
-        FontSecondary,
-        "Writing this file is\nnot supported for\nthis magic card.");
+    if(instance->source_uid_mismatch) {
+        size_t source_uid_len = 0;
+        nfc_device_get_uid(instance->source_dev, &source_uid_len);
+
+        FuriString* message = furi_string_alloc();
+        furi_string_printf(
+            message,
+            "Tag UID: %u bytes\nFile UID: %u bytes\nLengths must match.",
+            (unsigned)instance->gen1_uid_len,
+            (unsigned)source_uid_len);
+
+        widget_add_string_element(
+            widget, 1, 4, AlignLeft, AlignTop, FontPrimary, "UID Length Mismatch");
+        widget_add_string_multiline_element(
+            widget, 1, 17, AlignLeft, AlignTop, FontSecondary, furi_string_get_cstr(message));
+
+        furi_string_free(message);
+    } else {
+        widget_add_icon_element(widget, 73, 17, &I_DolphinCommon_56x48);
+        widget_add_string_element(
+            widget, 1, 4, AlignLeft, AlignTop, FontPrimary, "This is wrong card");
+        widget_add_string_multiline_element(
+            widget,
+            1,
+            17,
+            AlignLeft,
+            AlignTop,
+            FontSecondary,
+            "Writing this file is\nnot supported for\nthis magic card.");
+    }
     widget_add_button_element(
         widget, GuiButtonTypeLeft, "Retry", nfc_magic_scene_wrong_card_widget_callback, instance);
 


### PR DESCRIPTION
# What's new

Improves Mifare Classic magic-tag **detection** and the **Gen1 wipe** in the NFC Magic app, and adds a write-safety guard. (fap_version 1.11 → 1.12)

### Gen2 / CUID detection (new)
Previously a Gen2 magic card was only recognised by a 2-entry ATS whitelist; everything else fell through to a vague "It Might Be a Magic Card". Now:
- **CUID confirmation** via a **non-destructive** block-0 write probe — after authenticating sector 0 with the default key it sends only the *first* phase of the MIFARE write and reads the ACK/NAK; the 16-byte data phase is **never** transmitted and the field is dropped immediately, so block 0 is never modified (mirrors Proxmark3's `MifareCIdent`).
- **Static-nonce CUID (MF-3.2)** detection — samples the tag nonce across fresh field activations; a repeat ⇒ static.
- **ATS-fingerprint** detection retained (known magic products).
- Result screen shows the type on line 1 and the sub-type below:
  - `Magic Type: Gen 2` + `CUID` / `CUID. Static nonce` / `CUID. ATS`

### Gen1 4-byte vs 7-byte UID (new)
Gen1's backdoor wakeup is UID-length-agnostic, so after a Gen1 hit a standard ISO14443-3A activation reads the anticollision cascade. The result screen shows `Gen 1A/B` + `4-byte UID` / `7-byte UID`.

### Write UID-length safeguard (new, Gen1)
Writing a dump whose UID length differs from the target tag corrupts block 0 (wrong BCC / mangled UID). The file picker now rejects a length-mismatched source with a clear **"UID Length Mismatch"** screen (skipped when the tag length couldn't be determined, so it never over-blocks).

### Gen1 wipe — length-aware, zero UID (improved / fix)
Wipe now writes an **all-zero UID matching the tag's length** (4 or 7 bytes) with the correct BCC and ATQA (`0x0044` for 7-byte), via the SDK `mf_classic_set_uid`. **Fixes wiping a 7-byte Gen1 tag**, which previously wrote a 4-byte block 0 and corrupted it.

### UX / robustness
- Added a space to all user-facing `Gen N` labels (`Gen 1` / `Gen 2` / `Gen 4`).
- Clearer Classic-fallback screen: **"Magic Not Confirmed"** — *"Not a magic tag, or sector 0 key is non-standard. Try writing to confirm."*
- Fixed a `furi_check` crash during CUID/static-nonce probing (each probe now uses its own poller session).
- Hardened the tag-nonce read (a CRC-valid reply is no longer mistaken for a nonce).
- Leaner detection allocation (skips ~8 KB of write-only buffers per probe); diagnostic logging when a UID-length read fails.

No firmware changes — entirely within the app; reuses the existing Gen2 poller's crypto1/auth primitives.

### App size (RAM)

A FAP is loaded entirely into RAM, so **Total** below is the static RAM footprint. Built for f7, API 87.8, release (`COMPACT=1 DEBUG=0`):

| Build | .text | .data | .bss | Total (RAM) | .fap on disk |
|---|---|---|---|---|---|
| dev (1.11) | 34,167 | 16 | 0 | 34,183 | 94,600 |
| this PR (1.12) | 35,767 | 16 | 0 | 35,783 | 97,644 |
| **Δ** | **+1,600** | 0 | 0 | **+1,600 B (~1.6 KB)** | +3,044 |

Runtime heap during detection is transient (allocated per probe session and freed); the leaner detection allocation introduced here keeps that peak bounded.

# Verification

**Build:** part of the apps pack / `./fbt launch APPSRC=applications_user/nfc_magic`. Built & tested on f7, API 87.8.

**Hardware test matrix** (open the app → *Check Magic Tag*, hold card; for write/wipe use the per-type menu):

| Card | Expected result |
|---|---|
| Gen1, 4-byte UID | `Magic Type: Gen 1A/B` + `4-byte UID` |
| Gen1, 7-byte UID | `Magic Type: Gen 1A/B` + `7-byte UID` |
| Gen2 CUID (no ATS) | `Magic Type: Gen 2` + `CUID` |
| Gen2 CUID, static nonce | `Magic Type: Gen 2` + `CUID. Static nonce` |
| Gen2 CUID, known ATS | `Magic Type: Gen 2` + `CUID. ATS` |
| MIFARE Classic 1K (non-magic) | `Magic Not Confirmed` (not falsely CUID) |
| Gen4 GTU (regression) | `Magic Type: Gen 4 GTU` (not mislabelled Gen2) |

**Write safeguard:**
- 4-byte dump → 7-byte Gen1 tag (and vice-versa): blocked with **"UID Length Mismatch"**.
- Matching lengths: writes normally.

**Gen1 wipe:**
- Wipe a 4-byte Gen1 → reads back UID `00000000`, default keys.
- Wipe a 7-byte Gen1 → reads back UID `00000000000000`, ATQA `0044`, default keys; selectable by normal readers.

**Safety / regression:**
- No crash on any card; re-scan (Retry) and mid-scan card removal are clean.
- CUID write probe is non-destructive: block 0 unchanged on a non-magic Classic / Gen4 after scanning.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code is released under GPLv3 license and can be edited, or published according to the opensource license

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The detection/wipe/safeguard code was AI-generated under my direction. It: (1) adds a non-destructive block-0 write probe + static-nonce sampling to the Gen2 poller to classify CUID / CUID-static-nonce / CUID-ATS; (2) reads the Gen1 UID length via a standard ISO14443-3A activation and surfaces 4b/7b; (3) gates writes on a source/target UID-length match; (4) makes the Gen1 wipe length-aware with a zero UID via `mf_classic_set_uid`. All design decisions, wording, and full on-hardware validation were done by me; the code was reviewed (multi-pass) and adversarially checked before commit.
