### PR TITLE
fix: correct Fahrenheit label in multi converter

### DIFF
--- a/base_pack/multi_converter/multi_converter_units.h
+++ b/base_pack/multi_converter/multi_converter_units.h
@@ -71,7 +71,7 @@ static const MultiConverterUnit multi_converter_unit_far = {
     1,
     10,
     "FAR\0",
-    "Fahernheit\0",
+    "Fahrenheit\0",
     multi_converter_unit_temperature_convert,
     multi_converter_unit_temperature_allowed};
 static const MultiConverterUnit multi_converter_unit_kel = {


### PR DESCRIPTION
## Summary
- correct the multi converter's visible Fahrenheit unit label from Fahernheit to Fahrenheit

Fixes #217

## Notes
Submitted via fork and GitHub API without cloning the repository locally.