### PR TITLE
ci: auto-label PRs by pack and app category

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# Auto-applies pack/* labels to PRs based on which pack the changed app lives in.
+# Used by .github/workflows/labeler.yml (actions/labeler@v5).
+# Category (NFC / Games / …) is applied by a separate step in that workflow,
+# reading fap_category from the changed app's application.fam.
+# sync-labels is off, so these only ADD labels — manual labels are never stripped.
+
+"pack/base":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "base_pack/**"
+
+"pack/catalog":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps_source_code/**"
+
+"pack/non-catalog":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "non_catalog_apps/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,75 @@
+name: "PR Labeler"
+
+# Auto-labels PRs two ways:
+#   pack/*      — which pack the changed app lives in (path-based, see .github/labeler.yml)
+#   category/*  — the app's fap_category, read from the changed application.fam
+#
+# pull_request_target is used so PRs from forks can be labeled (a fork's default
+# token is read-only). This workflow never checks out or executes PR code — the
+# category step only fetches application.fam via the API and regexes one field.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Only add labels; never strip labels applied by hand.
+          sync-labels: false
+
+  category:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by fap_category
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Collect the app folders (pack/appname) this PR touches.
+          declare -A apps=()
+          while IFS= read -r f; do
+            case "$f" in
+              base_pack/*/*|apps_source_code/*/*|non_catalog_apps/*/*)
+                apps["$(printf '%s' "$f" | cut -d/ -f1-2)"]=1 ;;
+            esac
+          done < <(gh pr diff "$PR" --repo "$REPO" --name-only)
+
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "No app folders changed; nothing to categorize."
+            exit 0
+          fi
+
+          # Resolve each app's fap_category -> category/<slug>.
+          declare -A labels=()
+          for app in "${!apps[@]}"; do
+            fam=$(gh api "repos/$REPO/contents/$app/application.fam?ref=$HEAD_SHA" \
+                    --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+            cat=$(printf '%s' "$fam" | sed -nE 's/.*fap_category="?([^",]+)"?.*/\1/p' | head -1)
+            if [ -z "$cat" ]; then
+              echo "::warning::no fap_category found for $app"
+              continue
+            fi
+            slug=$(printf '%s' "$cat" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+            labels["category/$slug"]=1
+            echo "$app -> category/$slug"
+          done
+
+          if [ ${#labels[@]} -eq 0 ]; then
+            echo "No categories resolved."
+            exit 0
+          fi
+
+          args=()
+          for l in "${!labels[@]}"; do args+=(-f "labels[]=$l"); done
+          gh api "repos/$REPO/issues/$PR/labels" -X POST "${args[@]}"


### PR DESCRIPTION
## What

Adds an [`actions/labeler`](https://github.com/actions/labeler) config + workflow that automatically labels every PR two ways:

- **`pack/*`** — from the changed app's top folder: `base_pack/**` → `pack/base`, `apps_source_code/**` → `pack/catalog`, `non_catalog_apps/**` → `pack/non-catalog`.
- **`category/*`** — reads the changed app's `application.fam` `fap_category` (NFC, Games, Tools, …) and applies the matching `category/*` label.

Since a PR here almost always touches exactly one app folder, both are highly reliable.

## Notes

- `sync-labels: false` — labels are **only added**, never stripped, so anything applied by hand is preserved.
- Triggered via `pull_request_target` so PRs from forks can be labeled. The workflow **never checks out or executes PR code** — the category step only fetches `application.fam` through the API and extracts one field with `sed`.
- Requires the `pack/*` and `category/*` labels to exist (already created in the repo).

Worth a glance at the checks on the **first real PR** after merge to confirm the category step resolves as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)