### PR TITLE
chore: add issue templates that auto-apply type/* labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report a bug in one of the apps in this pack.
+labels: ["type/bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! This tracker is for the **apps** in this pack.
+        For bugs in the Unleashed firmware itself, please use the firmware repo instead.
+  - type: input
+    id: app
+    attributes:
+      label: App
+      description: Which app is affected? (name as it appears in the app menu)
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug.
+      description: A clear and concise description of what goes wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: How can this be reproduced?
+      placeholder: |
+        1. Open the app...
+        2. Press '...'
+        3. See the issue
+  - type: input
+    id: version
+    attributes:
+      label: Firmware version
+      description: Which Unleashed firmware version are you running?
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Logs, photos, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/02_new_app.yml
+++ b/.github/ISSUE_TEMPLATE/02_new_app.yml
@@ -1,0 +1,30 @@
+name: Add new app
+description: Request adding a new app to the pack.
+labels: ["type/new-app"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to request a new app be added to the pack.
+  - type: input
+    id: app
+    attributes:
+      label: App name
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source / repository link
+      description: Link to the app's source code.
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What does it do?
+      description: Short description of the app and its category (Sub-GHz, NFC, Games, ...).
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?

--- a/.github/ISSUE_TEMPLATE/03_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/03_enhancement.yml
@@ -1,0 +1,26 @@
+name: Enhancement
+description: Suggest an improvement to an existing app.
+labels: ["type/enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest an improvement to an app that's already in the pack.
+  - type: input
+    id: app
+    attributes:
+      label: App
+      description: Which app should be improved?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the enhancement.
+      description: What should it do differently?
+    validations:
+      required: true
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Firmware bug (not an app)
+    url: https://github.com/DarkFlippers/unleashed-firmware/issues/new/choose
+    about: For bugs in the Unleashed firmware itself, please open an issue in the firmware repo.


### PR DESCRIPTION
## What

The repo had no issue templates. Adds three GitHub issue forms so new issues are labeled at creation time, matching the new taxonomy:

| template | auto-label |
|---|---|
| Bug report | `type/bug` |
| Add new app | `type/new-app` |
| Enhancement | `type/enhancement` |

Each form asks **which app** is involved (helps triage/categorization). `config.yml` adds a contact link routing firmware (non-app) bugs to the firmware repo instead.

## Notes

- `category/*` still can't be auto-applied to *issues* (no file paths — category lives in `application.fam`), so that stays manual on issues. The "which app" field makes it a quick lookup.
- Complements #223 (PR auto-labeler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)