### PR TITLE
Update wardriving, add UBX & RPC

### DIFF
--- a/base_pack/subghz_wardriving/application.fam
+++ b/base_pack/subghz_wardriving/application.fam
@@ -8,7 +8,7 @@ App(
     fap_libs=["assets", "hwdrivers"],
     fap_icon="icon.png",
     fap_icon_assets="ex_icons",
-    sources=["*.c", "!helpers/subghz_wardriving_gps.c", "!helpers/minmea.c"],
+    sources=["*.c", "!helpers/subghz_wardriving_gps.c", "!helpers/minmea.c", "!helpers/ubox.c"],
     fap_category="Sub-GHz",
 )
 
@@ -18,6 +18,6 @@ App(
     apptype=FlipperAppType.PLUGIN,
     entry_point="subghz_gps_plugin_ep",
     requires=["subghz_wardriving"],
-    sources=["helpers/subghz_wardriving_gps.c", "helpers/minmea.c"],
+    sources=["helpers/subghz_wardriving_gps.c", "helpers/minmea.c", "helpers/ubox.c"],
     fal_embedded=True,
 )

--- a/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps.c
+++ b/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps.c
@@ -1,5 +1,6 @@
 #include "subghz_wardriving_gps.h"
 #include "minmea.h"
+#include "ubox.h"
 
 #define UART_CH (FuriHalSerialIdUsart)
 
@@ -65,6 +66,20 @@ static void subghz_gps_uart_on_irq_cb(
     }
 }
 
+static void subghz_gps_uart_parse_ubox(SubGhzGPS* subghz_gps, const uint8_t* data, size_t len) {
+    UboxPvt pvt;
+    for(size_t i = 0; i < len; i++) {
+        if(ubox_rx_byte(&subghz_gps->ubox, data[i], &pvt)) {
+            subghz_gps->latitude = pvt.lat * 1e-7f;
+            subghz_gps->longitude = pvt.lon * 1e-7f;
+            subghz_gps->satellites = pvt.sats;
+            subghz_gps->fix_hour = pvt.hour;
+            subghz_gps->fix_minute = pvt.min;
+            subghz_gps->fix_second = pvt.sec;
+        }
+    }
+}
+
 static int32_t subghz_gps_uart_worker(void* context) {
     SubGhzGPS* subghz_gps = (SubGhzGPS*)context;
 
@@ -88,31 +103,37 @@ static int32_t subghz_gps_uart_worker(void* context) {
                     RX_BUF_SIZE - rx_offset,
                     0);
 
-                if(len > 0) {
-                    rx_offset += len;
-                    subghz_gps->rx_buf[rx_offset] = '\0';
+                if(len == 0) continue;
 
-                    char* current_line = (char*)subghz_gps->rx_buf;
-                    while(true) {
-                        while(*current_line == '\0' &&
-                              current_line < (char*)subghz_gps->rx_buf + rx_offset) {
-                            current_line++;
-                        }
+                if(subghz_gps->protocol == SubGhzGpsProtocolUbox) {
+                    subghz_gps_uart_parse_ubox(subghz_gps, subghz_gps->rx_buf + rx_offset, len);
+                    rx_offset = 0;
+                    continue;
+                }
 
-                        char* next_line = strchr(current_line, '\n');
-                        if(next_line) {
-                            *next_line = '\0';
-                            subghz_gps_uart_parse_nmea(subghz_gps, current_line);
-                            current_line = next_line + 1;
-                        } else {
-                            if(current_line > (char*)subghz_gps->rx_buf) {
-                                rx_offset = 0;
-                                while(*current_line) {
-                                    subghz_gps->rx_buf[rx_offset++] = *(current_line++);
-                                }
+                rx_offset += len;
+                subghz_gps->rx_buf[rx_offset] = '\0';
+
+                char* current_line = (char*)subghz_gps->rx_buf;
+                while(true) {
+                    while(*current_line == '\0' &&
+                          current_line < (char*)subghz_gps->rx_buf + rx_offset) {
+                        current_line++;
+                    }
+
+                    char* next_line = strchr(current_line, '\n');
+                    if(next_line) {
+                        *next_line = '\0';
+                        subghz_gps_uart_parse_nmea(subghz_gps, current_line);
+                        current_line = next_line + 1;
+                    } else {
+                        if(current_line > (char*)subghz_gps->rx_buf) {
+                            rx_offset = 0;
+                            while(*current_line) {
+                                subghz_gps->rx_buf[rx_offset++] = *(current_line++);
                             }
-                            break;
                         }
+                        break;
                     }
                 }
             } while(len > 0);
@@ -137,77 +158,16 @@ static void subghz_gps_deinit(SubGhzGPS* subghz_gps) {
     furi_stream_buffer_free(subghz_gps->rx_stream);
 }
 
-static float subghz_gps_deg2rad(float deg) {
-    return (deg * M_PI / 180);
-}
-
-static float subghz_gps_calc_distance(float lat1d, float lon1d, float lat2d, float lon2d) {
-    float lat1r, lon1r, lat2r, lon2r;
-    double u, v;
-    lat1r = subghz_gps_deg2rad(lat1d);
-    lon1r = subghz_gps_deg2rad(lon1d);
-    lat2r = subghz_gps_deg2rad(lat2d);
-    lon2r = subghz_gps_deg2rad(lon2d);
-    u = sin((lat2r - lat1r) / 2);
-    v = sin((lon2r - lon1r) / 2);
-    return 2 * 6371 * asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
-}
-
-static float subghz_gps_calc_angle(float lat1, float lon1, float lat2, float lon2) {
-    return atan2(lat1 - lat2, lon1 - lon2) * 180 / (double)M_PI;
-}
-
-static void subghz_gps_cat_realtime(
-    SubGhzGPS* subghz_gps,
-    FuriString* descr,
-    float latitude,
-    float longitude) {
-    float distance =
-        subghz_gps_calc_distance(latitude, longitude, subghz_gps->latitude, subghz_gps->longitude);
-
-    float angle =
-        subghz_gps_calc_angle(latitude, longitude, subghz_gps->latitude, subghz_gps->longitude);
-
-    char* angle_str = "?";
-    if(angle > -22.5 && angle <= 22.5) {
-        angle_str = "E";
-    } else if(angle > 22.5 && angle <= 67.5) {
-        angle_str = "NE";
-    } else if(angle > 67.5 && angle <= 112.5) {
-        angle_str = "N";
-    } else if(angle > 112.5 && angle <= 157.5) {
-        angle_str = "NW";
-    } else if(angle < -22.5 && angle >= -67.5) {
-        angle_str = "SE";
-    } else if(angle < -67.5 && angle >= -112.5) {
-        angle_str = "S";
-    } else if(angle < -112.5 && angle >= -157.5) {
-        angle_str = "SW";
-    } else if(angle < -157.5 || angle >= 157.5) {
-        angle_str = "W";
-    }
-
-    furi_string_cat_printf(
-        descr,
-        "Realtime:  Sats: %d\r\n"
-        "Distance: %.2f%s Dir: %s\r\n"
-        "GPS time: %02d:%02d:%02d UTC",
-        subghz_gps->satellites,
-        (double)(subghz_gps->satellites > 0 ? distance > 1 ? distance : distance * 1000 : 0),
-        distance > 1 ? "km" : "m",
-        angle_str,
-        subghz_gps->fix_hour,
-        subghz_gps->fix_minute,
-        subghz_gps->fix_second);
-}
-
-static void subghz_gps_init(SubGhzGPS* subghz_gps, uint32_t baudrate) {
+static void subghz_gps_init(SubGhzGPS* subghz_gps, SubGhzGpsProtocol protocol, uint32_t baudrate) {
     subghz_gps->latitude = NAN;
     subghz_gps->longitude = NAN;
     subghz_gps->satellites = 0;
     subghz_gps->fix_hour = 0;
     subghz_gps->fix_minute = 0;
     subghz_gps->fix_second = 0;
+
+    subghz_gps->protocol = protocol;
+    ubox_rx_init(&subghz_gps->ubox);
 
     subghz_gps->rx_stream = furi_stream_buffer_alloc(RX_BUF_SIZE, 1);
 
@@ -223,12 +183,11 @@ static void subghz_gps_init(SubGhzGPS* subghz_gps, uint32_t baudrate) {
         subghz_gps->serial_handle, subghz_gps_uart_on_irq_cb, subghz_gps, false);
 
     subghz_gps->deinit = &subghz_gps_deinit;
-    subghz_gps->cat_realtime = &subghz_gps_cat_realtime;
 }
 
 static const FlipperAppPluginDescriptor plugin_descriptor = {
     .appid = "subghz_plugin_gps",
-    .ep_api_version = 1,
+    .ep_api_version = 2,
     .entry_point = &subghz_gps_init,
 };
 

--- a/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps.h
+++ b/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps.h
@@ -2,18 +2,35 @@
 
 #include <furi_hal.h>
 #include <flipper_application/flipper_application.h>
+#include <gps/gps.h>
+#include "ubox.h"
 
 #define RX_BUF_SIZE 1024
+
+// Order matches the config menu.
+typedef enum {
+    SubGhzGpsProtocolOff,
+    SubGhzGpsProtocolRpc,
+    SubGhzGpsProtocolNmea,
+    SubGhzGpsProtocolUbox,
+} SubGhzGpsProtocol;
 
 typedef struct SubGhzGPS SubGhzGPS;
 
 struct SubGhzGPS {
-    FlipperApplication* plugin_app;
+    FlipperApplication* plugin_app; // set for the UART plugin, NULL for inline RPC
     FuriThread* thread;
     FuriStreamBuffer* rx_stream;
     uint8_t rx_buf[RX_BUF_SIZE];
     FuriHalSerialHandle* serial_handle;
+    SubGhzGpsProtocol protocol;
+    UboxRx ubox;
     FuriTimer* timer;
+
+    // inline RPC transport (RECORD_GPS), unused by the UART plugin
+    Gps* rpc;
+    FuriTimer* rpc_timer;
+    uint32_t rpc_last_rx;
 
     float latitude;
     float longitude;
@@ -22,39 +39,35 @@ struct SubGhzGPS {
     uint8_t fix_minute;
     uint8_t fix_hour;
 
-    /**
-     * Deinitialize SubGhzGPS object
-     * To be used by plugin handler
-     * 
-     * @param subghz_gps SubGhzGPS object
-     * @return void
-    */
     void (*deinit)(SubGhzGPS* subghz_gps);
-
-    /**
-     * Concatenate realtime GPS info to string
-     * 
-     * @param subghz_gps SubGhzGPS object
-     * @param descr Output string
-     * @param latitude Latitude
-     * @param longitude Longitude
-     * @return void
-    */
-    void (*cat_realtime)(SubGhzGPS* subghz_gps, FuriString* descr, float latitude, float longitude);
 };
 
-/**
- * Initialize SubGhzGPS plugin
- * Fails and returns NULL if Expansion is connected
- *
- * @return SubGhzGPS* SubGhzGPS object
-*/
-SubGhzGPS* subghz_gps_plugin_init(uint32_t baudrate);
+// Realtime info string (distance/direction/sats/time), shared by all sources.
+void subghz_gps_cat_realtime(
+    SubGhzGPS* subghz_gps,
+    FuriString* descr,
+    float latitude,
+    float longitude);
 
 /**
- * Deinitialize SubGhzGPS plugin
- * 
- * @param subghz_gps SubGhzGPS object
- * @return void
+ * Load the UART GPS plugin (.fal) for NMEA or Ubox.
+ *
+ * @return SubGhzGPS* object, or NULL on load failure
+*/
+SubGhzGPS* subghz_gps_plugin_init(SubGhzGpsProtocol protocol, uint32_t baudrate);
+
+/**
+ * Unload the UART GPS plugin.
 */
 void subghz_gps_plugin_deinit(SubGhzGPS* subghz_gps);
+
+/**
+ * Start the inline RPC GPS source (RECORD_GPS, companion over USB/BLE).
+ * No plugin is loaded. Returns a SubGhzGPS with the same data contract.
+*/
+SubGhzGPS* subghz_gps_rpc_start(void);
+
+/**
+ * Stop the inline RPC GPS source.
+*/
+void subghz_gps_rpc_stop(SubGhzGPS* subghz_gps);

--- a/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps_plugin.c
+++ b/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps_plugin.c
@@ -3,10 +3,74 @@
 //#include <expansion/expansion.h>
 #include <loader/firmware_api/firmware_api.h>
 #include <inttypes.h>
+#include <math.h>
 
 #define TAG "SubGhzWarDrivingGPS"
 
-SubGhzGPS* subghz_gps_plugin_init(uint32_t baudrate) {
+// Single-precision Haversine so the always-loaded FAP avoids the heavy double
+// soft-float (sqrtf is the M4F hardware VSQRT.F32).
+static float subghz_gps_deg2rad(float deg) {
+    return deg * (float)M_PI / 180.0f;
+}
+
+static float subghz_gps_calc_distance(float lat1d, float lon1d, float lat2d, float lon2d) {
+    float lat1r = subghz_gps_deg2rad(lat1d);
+    float lon1r = subghz_gps_deg2rad(lon1d);
+    float lat2r = subghz_gps_deg2rad(lat2d);
+    float lon2r = subghz_gps_deg2rad(lon2d);
+    float u = sinf((lat2r - lat1r) / 2.0f);
+    float v = sinf((lon2r - lon1r) / 2.0f);
+    return 2.0f * 6371.0f * asinf(sqrtf(u * u + cosf(lat1r) * cosf(lat2r) * v * v));
+}
+
+static float subghz_gps_calc_angle(float lat1, float lon1, float lat2, float lon2) {
+    return atan2f(lat1 - lat2, lon1 - lon2) * 180.0f / (float)M_PI;
+}
+
+void subghz_gps_cat_realtime(
+    SubGhzGPS* subghz_gps,
+    FuriString* descr,
+    float latitude,
+    float longitude) {
+    float distance =
+        subghz_gps_calc_distance(latitude, longitude, subghz_gps->latitude, subghz_gps->longitude);
+    float angle =
+        subghz_gps_calc_angle(latitude, longitude, subghz_gps->latitude, subghz_gps->longitude);
+
+    char* angle_str = "?";
+    if(angle > -22.5f && angle <= 22.5f) {
+        angle_str = "E";
+    } else if(angle > 22.5f && angle <= 67.5f) {
+        angle_str = "NE";
+    } else if(angle > 67.5f && angle <= 112.5f) {
+        angle_str = "N";
+    } else if(angle > 112.5f && angle <= 157.5f) {
+        angle_str = "NW";
+    } else if(angle < -22.5f && angle >= -67.5f) {
+        angle_str = "SE";
+    } else if(angle < -67.5f && angle >= -112.5f) {
+        angle_str = "S";
+    } else if(angle < -112.5f && angle >= -157.5f) {
+        angle_str = "SW";
+    } else if(angle < -157.5f || angle >= 157.5f) {
+        angle_str = "W";
+    }
+
+    furi_string_cat_printf(
+        descr,
+        "Realtime:  Sats: %d\r\n"
+        "Distance: %.2f%s Dir: %s\r\n"
+        "GPS time: %02d:%02d:%02d UTC",
+        subghz_gps->satellites,
+        (double)(subghz_gps->satellites > 0 ? distance > 1 ? distance : distance * 1000 : 0),
+        distance > 1 ? "km" : "m",
+        angle_str,
+        subghz_gps->fix_hour,
+        subghz_gps->fix_minute,
+        subghz_gps->fix_second);
+}
+
+SubGhzGPS* subghz_gps_plugin_init(SubGhzGpsProtocol protocol, uint32_t baudrate) {
     //bool connected = expansion_is_connected(furi_record_open(RECORD_EXPANSION));
     //furi_record_close(RECORD_EXPANSION);
     //if(connected) return NULL;
@@ -44,7 +108,7 @@ SubGhzGPS* subghz_gps_plugin_init(uint32_t baudrate) {
             break;
         }
 
-        if(app_descriptor->ep_api_version != 1) {
+        if(app_descriptor->ep_api_version != 2) {
             FURI_LOG_E(
                 TAG,
                 "GPS plugin version %" PRIu32 " doesn't match\r\n",
@@ -52,12 +116,13 @@ SubGhzGPS* subghz_gps_plugin_init(uint32_t baudrate) {
             break;
         }
 
-        void (*subghz_gps_init)(SubGhzGPS* subghz_gps, uint32_t baudrate) =
+        void (*subghz_gps_init)(
+            SubGhzGPS* subghz_gps, SubGhzGpsProtocol protocol, uint32_t baudrate) =
             app_descriptor->entry_point;
 
         SubGhzGPS* subghz_gps = malloc(sizeof(SubGhzGPS));
         subghz_gps->plugin_app = plugin_app;
-        subghz_gps_init(subghz_gps, baudrate);
+        subghz_gps_init(subghz_gps, protocol, baudrate);
         return subghz_gps;
 
     } while(false);

--- a/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps_rpc.c
+++ b/base_pack/subghz_wardriving/helpers/subghz_wardriving_gps_rpc.c
@@ -1,0 +1,68 @@
+#include "subghz_wardriving_gps.h"
+
+#define RPC_STREAM_FREQ       10
+#define RPC_POLL_PERIOD_MS    1000
+#define RPC_STREAM_TIMEOUT_MS 3000
+
+static void subghz_gps_rpc_callback(GpsStatus status, const GpsLocation* location, void* context) {
+    SubGhzGPS* subghz_gps = context;
+    subghz_gps->rpc_last_rx = furi_get_tick();
+
+    if(status == GpsStatusOk && location) {
+        subghz_gps->latitude = location->latitude * 1e-7f;
+        subghz_gps->longitude = location->longitude * 1e-7f;
+        subghz_gps->satellites = location->satellites;
+        DateTime datetime;
+        furi_hal_rtc_get_datetime(&datetime);
+        subghz_gps->fix_hour = datetime.hour;
+        subghz_gps->fix_minute = datetime.minute;
+        subghz_gps->fix_second = datetime.second;
+    } else {
+        subghz_gps->latitude = NAN;
+        subghz_gps->longitude = NAN;
+        subghz_gps->satellites = 0;
+        subghz_gps->fix_hour = 0;
+        subghz_gps->fix_minute = 0;
+        subghz_gps->fix_second = 0;
+    }
+}
+
+static void subghz_gps_rpc_poll(void* context) {
+    SubGhzGPS* subghz_gps = context;
+    if(furi_get_tick() - subghz_gps->rpc_last_rx >= furi_ms_to_ticks(RPC_STREAM_TIMEOUT_MS)) {
+        gps_request_stream(subghz_gps->rpc, RPC_STREAM_FREQ);
+    }
+}
+
+SubGhzGPS* subghz_gps_rpc_start(void) {
+    SubGhzGPS* subghz_gps = malloc(sizeof(SubGhzGPS));
+    memset(subghz_gps, 0, sizeof(SubGhzGPS));
+
+    subghz_gps->plugin_app = NULL;
+    subghz_gps->protocol = SubGhzGpsProtocolRpc;
+    subghz_gps->latitude = NAN;
+    subghz_gps->longitude = NAN;
+
+    subghz_gps->rpc = furi_record_open(RECORD_GPS);
+    gps_set_location_callback(subghz_gps->rpc, subghz_gps_rpc_callback, subghz_gps);
+
+    gps_request_stream(subghz_gps->rpc, RPC_STREAM_FREQ);
+    subghz_gps->rpc_timer =
+        furi_timer_alloc(subghz_gps_rpc_poll, FuriTimerTypePeriodic, subghz_gps);
+    furi_timer_start(subghz_gps->rpc_timer, furi_ms_to_ticks(RPC_POLL_PERIOD_MS));
+
+    return subghz_gps;
+}
+
+void subghz_gps_rpc_stop(SubGhzGPS* subghz_gps) {
+    furi_assert(subghz_gps);
+
+    furi_timer_stop(subghz_gps->rpc_timer);
+    furi_timer_free(subghz_gps->rpc_timer);
+
+    gps_stop_stream(subghz_gps->rpc);
+    gps_set_location_callback(subghz_gps->rpc, NULL, NULL);
+    furi_record_close(RECORD_GPS);
+
+    free(subghz_gps);
+}

--- a/base_pack/subghz_wardriving/helpers/ubox.c
+++ b/base_pack/subghz_wardriving/helpers/ubox.c
@@ -1,0 +1,101 @@
+#include "ubox.h"
+
+static inline void ubox_checksum(UboxRx* rx, uint8_t byte) {
+    rx->calc_a += byte;
+    rx->calc_b += rx->calc_a;
+}
+
+static inline uint32_t ubox_get_u32(const uint8_t* p, size_t offset) {
+    return (uint32_t)p[offset] | ((uint32_t)p[offset + 1] << 8) | ((uint32_t)p[offset + 2] << 16) |
+           ((uint32_t)p[offset + 3] << 24);
+}
+
+static inline void ubox_restart(UboxRx* rx) {
+    rx->state = UboxStateSync1;
+    rx->index = 0;
+    rx->calc_a = 0;
+    rx->calc_b = 0;
+}
+
+void ubox_rx_init(UboxRx* rx) {
+    *rx = (UboxRx){0};
+}
+
+bool ubox_rx_byte(UboxRx* rx, uint8_t byte, UboxPvt* out) {
+    switch(rx->state) {
+    case UboxStateSync1:
+        if(byte == UBX_SYNC1) {
+            ubox_restart(rx);
+            rx->state = UboxStateSync2;
+        }
+        break;
+
+    case UboxStateSync2:
+        if(byte == UBX_SYNC2) {
+            rx->state = UboxStateClass;
+        } else if(byte != UBX_SYNC1) {
+            rx->state = UboxStateSync1;
+        }
+        break;
+
+    case UboxStateClass:
+        rx->msg_class = byte;
+        ubox_checksum(rx, byte);
+        rx->state = UboxStateId;
+        break;
+
+    case UboxStateId:
+        rx->msg_id = byte;
+        ubox_checksum(rx, byte);
+        rx->state = UboxStateLen1;
+        break;
+
+    case UboxStateLen1:
+        rx->len = byte;
+        ubox_checksum(rx, byte);
+        rx->state = UboxStateLen2;
+        break;
+
+    case UboxStateLen2:
+        rx->len |= (uint16_t)byte << 8;
+        ubox_checksum(rx, byte);
+        rx->index = 0;
+        rx->state = rx->len ? UboxStatePayload : UboxStateCkA;
+        break;
+
+    case UboxStatePayload:
+        // Store only what fits; longer messages are still walked past (and
+        // checksummed) so the parser stays in sync, then dropped as non-PVT.
+        if(rx->index < UBX_NAV_PVT_LEN) rx->payload[rx->index] = byte;
+        rx->index++;
+        ubox_checksum(rx, byte);
+        if(rx->index == rx->len) rx->state = UboxStateCkA;
+        break;
+
+    case UboxStateCkA:
+        rx->ck_a = byte;
+        rx->state = UboxStateCkB;
+        break;
+
+    case UboxStateCkB: {
+        rx->ck_b = byte;
+        bool ok = rx->calc_a == rx->ck_a && rx->calc_b == rx->ck_b;
+        rx->state = UboxStateSync1;
+        if(ok && rx->msg_class == UBX_NAV_CLASS && rx->msg_id == UBX_NAV_PVT_ID &&
+           rx->len == UBX_NAV_PVT_LEN) {
+            const uint8_t* p = rx->payload;
+            out->hour = p[8];
+            out->min = p[9];
+            out->sec = p[10];
+            out->valid = p[21] & 0x01; // flags: gnssFixOK
+            out->sats = p[23];
+            out->lon = (int32_t)ubox_get_u32(p, 24);
+            out->lat = (int32_t)ubox_get_u32(p, 28);
+            return true;
+        }
+        break;
+    }
+    }
+
+    return false;
+}

--- a/base_pack/subghz_wardriving/helpers/ubox.h
+++ b/base_pack/subghz_wardriving/helpers/ubox.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// Minimal RX-only u-blox UBX parser, by apfxtech
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define UBX_SYNC1       0xB5
+#define UBX_SYNC2       0x62
+#define UBX_NAV_CLASS   0x01
+#define UBX_NAV_PVT_ID  0x07
+#define UBX_NAV_PVT_LEN 92
+
+typedef enum {
+    UboxStateSync1,
+    UboxStateSync2,
+    UboxStateClass,
+    UboxStateId,
+    UboxStateLen1,
+    UboxStateLen2,
+    UboxStatePayload,
+    UboxStateCkA,
+    UboxStateCkB,
+} UboxState;
+
+typedef struct {
+    UboxState state;
+    uint8_t msg_class;
+    uint8_t msg_id;
+    uint16_t len;
+    uint16_t index;
+    uint8_t ck_a;
+    uint8_t ck_b;
+    uint8_t calc_a;
+    uint8_t calc_b;
+    uint8_t payload[UBX_NAV_PVT_LEN];
+} UboxRx;
+
+typedef struct {
+    int32_t lat; /**< Latitude in degrees * 1e7 */
+    int32_t lon; /**< Longitude in degrees * 1e7 */
+    uint8_t sats; /**< Satellites used in fix */
+    uint8_t hour;
+    uint8_t min;
+    uint8_t sec;
+    bool valid; /**< gnssFixOK */
+} UboxPvt;
+
+/** Reset the parser to its initial state */
+void ubox_rx_init(UboxRx* rx);
+
+/**
+ * Feed a single byte to the parser.
+ *
+ * @param rx    Parser state
+ * @param byte  Incoming byte
+ * @param out   Filled with the decoded fix when a NAV-PVT frame completes
+ * @return true when *out was updated with a fresh NAV-PVT
+ */
+bool ubox_rx_byte(UboxRx* rx, uint8_t byte, UboxPvt* out);

--- a/base_pack/subghz_wardriving/scenes/subghz_wardriving_scene_radio_settings.c
+++ b/base_pack/subghz_wardriving/scenes/subghz_wardriving_scene_radio_settings.c
@@ -20,15 +20,31 @@ const char* const on_off_text[ON_OFF_COUNT] = {
     "ON",
 };
 
-#define GPS_COUNT 7
-const char* const gps_text[GPS_COUNT] = {
+// index == SubGhzGpsProtocol
+#define GPS_PROTOCOL_COUNT 4
+const char* const gps_protocol_text[GPS_PROTOCOL_COUNT] = {
     "OFF",
+    "RPC",
+    "NMEA",
+    "Ubox",
+};
+
+#define GPS_BAUDRATE_COUNT 6
+const char* const gps_baudrate_text[GPS_BAUDRATE_COUNT] = {
     "4800",
     "9600",
     "19200",
     "38400",
     "57600",
     "115200",
+};
+const uint32_t gps_baudrate_value[GPS_BAUDRATE_COUNT] = {
+    4800,
+    9600,
+    19200,
+    38400,
+    57600,
+    115200,
 };
 
 #define DEBUG_COUNTER_COUNT 17
@@ -120,44 +136,23 @@ static void subghz_scene_receiver_config_set_debug_counter(VariableItem* item) {
     furi_hal_subghz_set_rolling_counter_mult(debug_counter_val[index]);
 }
 
-static void subghz_scene_receiver_config_set_gps(VariableItem* item) {
+// Config only saves; the source is applied once at app start (no plugin reloads).
+static void subghz_scene_receiver_config_set_gps_protocol(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
 
-    variable_item_set_current_value_text(item, gps_text[index]);
-
-    switch(index) {
-    case 0:
-        subghz->last_settings->gps_baudrate = 0;
-        break;
-    case 1:
-        subghz->last_settings->gps_baudrate = 4800;
-        break;
-    case 2:
-        subghz->last_settings->gps_baudrate = 9600;
-        break;
-    case 3:
-        subghz->last_settings->gps_baudrate = 19200;
-        break;
-    case 4:
-        subghz->last_settings->gps_baudrate = 38400;
-        break;
-    case 5:
-        subghz->last_settings->gps_baudrate = 57600;
-        break;
-    case 6:
-        subghz->last_settings->gps_baudrate = 115200;
-        break;
-    }
+    variable_item_set_current_value_text(item, gps_protocol_text[index]);
+    subghz->last_settings->gps_protocol = index;
     subghz_wardriving_last_settings_save(subghz->last_settings);
+}
 
-    if(subghz->gps) {
-        subghz_gps_plugin_deinit(subghz->gps);
-        subghz->gps = NULL;
-    }
-    if(subghz->last_settings->gps_baudrate != 0) {
-        subghz->gps = subghz_gps_plugin_init(subghz->last_settings->gps_baudrate);
-    }
+static void subghz_scene_receiver_config_set_gps_baudrate(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, gps_baudrate_text[index]);
+    subghz->last_settings->gps_baudrate = gps_baudrate_value[index];
+    subghz_wardriving_last_settings_save(subghz->last_settings);
 }
 
 static void subghz_scene_receiver_config_set_protocol_file_names(VariableItem* item) {
@@ -209,16 +204,25 @@ void subghz_scene_radio_settings_on_enter(void* context) {
 
     item = variable_item_list_add(
         variable_item_list,
+        "GPS",
+        GPS_PROTOCOL_COUNT,
+        subghz_scene_receiver_config_set_gps_protocol,
+        subghz);
+    value_index = subghz->last_settings->gps_protocol;
+    if(value_index >= GPS_PROTOCOL_COUNT) value_index = 0;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, gps_protocol_text[value_index]);
+
+    item = variable_item_list_add(
+        variable_item_list,
         "GPS Baudrate",
-        GPS_COUNT,
-        subghz_scene_receiver_config_set_gps,
+        GPS_BAUDRATE_COUNT,
+        subghz_scene_receiver_config_set_gps_baudrate,
         subghz);
     value_index = value_index_uint32(
-        subghz->last_settings->gps_baudrate,
-        (const uint32_t[]){0, 4800, 9600, 19200, 38400, 57600, 115200},
-        GPS_COUNT);
+        subghz->last_settings->gps_baudrate, gps_baudrate_value, GPS_BAUDRATE_COUNT);
     variable_item_set_current_value_index(item, value_index);
-    variable_item_set_current_value_text(item, gps_text[value_index]);
+    variable_item_set_current_value_text(item, gps_baudrate_text[value_index]);
 
     item = variable_item_list_add(
         variable_item_list,

--- a/base_pack/subghz_wardriving/scenes/subghz_wardriving_scene_show_gps.c
+++ b/base_pack/subghz_wardriving/scenes/subghz_wardriving_scene_show_gps.c
@@ -35,7 +35,7 @@ void subghz_scene_show_gps_draw_satellites(void* context) {
             subghz->gps->fix_second = 0;
         }
 
-        subghz->gps->cat_realtime(subghz->gps, text_str, latitude, longitude);
+        subghz_gps_cat_realtime(subghz->gps, text_str, latitude, longitude);
     }
 
     widget_add_text_scroll_element(subghz->widget, 0, 0, 128, 64, furi_string_get_cstr(text_str));

--- a/base_pack/subghz_wardriving/subghz_wardriving.c
+++ b/base_pack/subghz_wardriving/subghz_wardriving.c
@@ -172,8 +172,19 @@ SubGhz* subghz_alloc() {
     //Init Error_str
     subghz->error_str = furi_string_alloc();
 
-    if(subghz->last_settings->gps_baudrate != 0) {
-        subghz->gps = subghz_gps_plugin_init(subghz->last_settings->gps_baudrate);
+    subghz->gps = NULL;
+    switch(subghz->last_settings->gps_protocol) {
+    case SubGhzGpsProtocolNmea:
+    case SubGhzGpsProtocolUbox: {
+        uint32_t baud = subghz->last_settings->gps_baudrate ? subghz->last_settings->gps_baudrate :
+                                                              9600;
+        subghz->gps = subghz_gps_plugin_init(subghz->last_settings->gps_protocol, baud);
+    } break;
+    case SubGhzGpsProtocolRpc:
+        subghz->gps = subghz_gps_rpc_start();
+        break;
+    default:
+        break;
     }
 
     return subghz;
@@ -249,7 +260,11 @@ void subghz_free(SubGhz* subghz) {
 
     // GPS
     if(subghz->gps) {
-        subghz_gps_plugin_deinit(subghz->gps);
+        if(subghz->gps->plugin_app) {
+            subghz_gps_plugin_deinit(subghz->gps);
+        } else {
+            subghz_gps_rpc_stop(subghz->gps);
+        }
     }
 
     subghz_wardriving_last_settings_free(subghz->last_settings);

--- a/base_pack/subghz_wardriving/subghz_wardriving_last_settings.c
+++ b/base_pack/subghz_wardriving/subghz_wardriving_last_settings.c
@@ -7,15 +7,16 @@
 #define SUBGHZ_LAST_SETTING_FILE_VERSION 3
 #define SUBGHZ_LAST_SETTINGS_PATH        APP_DATA_PATH("subghz_wardriving_last.settings")
 
-#define SUBGHZ_LAST_SETTING_FIELD_FREQUENCY                         "Frequency"
-#define SUBGHZ_LAST_SETTING_FIELD_PRESET                            "Preset" // AKA Modulation
-#define SUBGHZ_LAST_SETTING_FIELD_PROTOCOL_FILE_NAMES               "ProtocolNames"
-#define SUBGHZ_LAST_SETTING_FIELD_HOPPING_ENABLE                    "Hopping"
-#define SUBGHZ_LAST_SETTING_FIELD_IGNORE_FILTER                     "IgnoreFilter"
-#define SUBGHZ_LAST_SETTING_FIELD_FILTER                            "Filter"
-#define SUBGHZ_LAST_SETTING_FIELD_RSSI_THRESHOLD                    "RSSI"
-#define SUBGHZ_LAST_SETTING_FIELD_DELETE_OLD                        "DelOldSignals"
+#define SUBGHZ_LAST_SETTING_FIELD_FREQUENCY           "Frequency"
+#define SUBGHZ_LAST_SETTING_FIELD_PRESET              "Preset" // AKA Modulation
+#define SUBGHZ_LAST_SETTING_FIELD_PROTOCOL_FILE_NAMES "ProtocolNames"
+#define SUBGHZ_LAST_SETTING_FIELD_HOPPING_ENABLE      "Hopping"
+#define SUBGHZ_LAST_SETTING_FIELD_IGNORE_FILTER       "IgnoreFilter"
+#define SUBGHZ_LAST_SETTING_FIELD_FILTER              "Filter"
+#define SUBGHZ_LAST_SETTING_FIELD_RSSI_THRESHOLD      "RSSI"
+#define SUBGHZ_LAST_SETTING_FIELD_DELETE_OLD          "DelOldSignals"
 
+#define SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL      "GpsProtocol"
 #define SUBGHZ_LAST_SETTING_FIELD_GPS_BAUDRATE      "GpsBaudrate"
 #define SUBGHZ_LAST_SETTING_FIELD_REMOVE_DUPLICATES "RemoveDuplicates"
 #define SUBGHZ_LAST_SETTING_FIELD_REPEATER          "Repeater"
@@ -45,6 +46,8 @@ void subghz_wardriving_last_settings_load(SubGhzLastSettings* instance, size_t p
     instance->filter = SubGhzProtocolFlag_Decodable;
     instance->rssi = SUBGHZ_RAW_THRESHOLD_MIN;
     instance->hopping_threshold = -90.0f;
+    instance->gps_protocol = SubGhzGpsProtocolRpc;
+    instance->gps_baudrate = 0;
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
@@ -110,6 +113,13 @@ void subghz_wardriving_last_settings_load(SubGhzLastSettings* instance, size_t p
                    fff_data_file,
                    SUBGHZ_LAST_SETTING_FIELD_GPS_BAUDRATE,
                    &instance->gps_baudrate,
+                   1)) {
+                flipper_format_rewind(fff_data_file);
+            }
+            if(!flipper_format_read_uint32(
+                   fff_data_file,
+                   SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL,
+                   &instance->gps_protocol,
                    1)) {
                 flipper_format_rewind(fff_data_file);
             }
@@ -228,6 +238,10 @@ bool subghz_wardriving_last_settings_save(SubGhzLastSettings* instance) {
 
         if(!flipper_format_write_uint32(
                file, SUBGHZ_LAST_SETTING_FIELD_GPS_BAUDRATE, &instance->gps_baudrate, 1)) {
+            break;
+        }
+        if(!flipper_format_write_uint32(
+               file, SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL, &instance->gps_protocol, 1)) {
             break;
         }
         if(!flipper_format_write_bool(

--- a/base_pack/subghz_wardriving/subghz_wardriving_last_settings.c
+++ b/base_pack/subghz_wardriving/subghz_wardriving_last_settings.c
@@ -46,7 +46,7 @@ void subghz_wardriving_last_settings_load(SubGhzLastSettings* instance, size_t p
     instance->filter = SubGhzProtocolFlag_Decodable;
     instance->rssi = SUBGHZ_RAW_THRESHOLD_MIN;
     instance->hopping_threshold = -90.0f;
-    instance->gps_protocol = SubGhzGpsProtocolRpc;
+    instance->gps_protocol = SubGhzGpsProtocolOff;
     instance->gps_baudrate = 0;
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
@@ -116,13 +116,6 @@ void subghz_wardriving_last_settings_load(SubGhzLastSettings* instance, size_t p
                    1)) {
                 flipper_format_rewind(fff_data_file);
             }
-            if(!flipper_format_read_uint32(
-                   fff_data_file,
-                   SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL,
-                   &instance->gps_protocol,
-                   1)) {
-                flipper_format_rewind(fff_data_file);
-            }
             if(!flipper_format_read_bool(
                    fff_data_file,
                    SUBGHZ_LAST_SETTING_FIELD_REMOVE_DUPLICATES,
@@ -161,6 +154,15 @@ void subghz_wardriving_last_settings_load(SubGhzLastSettings* instance, size_t p
                 flipper_format_rewind(fff_data_file);
             }
             instance->tx_power = (uint8_t)(tx_power & 0xFF);
+            if(!flipper_format_read_uint32(
+                   fff_data_file,
+                   SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL,
+                   &instance->gps_protocol,
+                   1)) {
+                flipper_format_rewind(fff_data_file);
+                instance->gps_protocol = (instance->gps_baudrate != 0) ? SubGhzGpsProtocolNmea :
+                                                                         SubGhzGpsProtocolOff;
+            }
         } while(0);
     } else {
         FURI_LOG_E(TAG, "Error open file %s", SUBGHZ_LAST_SETTINGS_PATH);
@@ -240,10 +242,6 @@ bool subghz_wardriving_last_settings_save(SubGhzLastSettings* instance) {
                file, SUBGHZ_LAST_SETTING_FIELD_GPS_BAUDRATE, &instance->gps_baudrate, 1)) {
             break;
         }
-        if(!flipper_format_write_uint32(
-               file, SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL, &instance->gps_protocol, 1)) {
-            break;
-        }
         if(!flipper_format_write_bool(
                file,
                SUBGHZ_LAST_SETTING_FIELD_REMOVE_DUPLICATES,
@@ -272,6 +270,11 @@ bool subghz_wardriving_last_settings_save(SubGhzLastSettings* instance) {
         }
         uint32_t tx_power = instance->tx_power;
         if(!flipper_format_write_uint32(file, SUBGHZ_LAST_SETTING_FIELD_TX_POWER, &tx_power, 1)) {
+            break;
+        }
+        // Appended last to keep older config files compatible.
+        if(!flipper_format_write_uint32(
+               file, SUBGHZ_LAST_SETTING_FIELD_GPS_PROTOCOL, &instance->gps_protocol, 1)) {
             break;
         }
         saved = true;

--- a/base_pack/subghz_wardriving/subghz_wardriving_last_settings.h
+++ b/base_pack/subghz_wardriving/subghz_wardriving_last_settings.h
@@ -20,6 +20,7 @@ typedef struct {
     uint32_t filter;
     float rssi;
     bool delete_old_signals;
+    uint32_t gps_protocol; // SubGhzGpsProtocol
     uint32_t gps_baudrate;
     bool remove_duplicates;
     uint32_t repeater_state;


### PR DESCRIPTION
# What's new

Update wardriving, add UBX (UBOX) & RPC

# Verification 

* Add u-blox UBX ("Ubox") parsing to the UART GPS plugin next to NMEA; protocol is selectable in Radio Settings.
* Add an RPC GPS: companion location over USB/BLE through the firmware RECORD_GPS service, handled inline in the app. Source is chosen once at startup and the UART plugin and RPC are mutually exclusive.
* Compute realtime distance/direction with one shared single-precision (float) Haversine instead of per-source double cat_realtime. This drops ~10 KB of double soft-float from the FAP.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [  ] I have commented my code, particularly in hard-to-understand areas
- [x] My code is released under GPLv3 license and can be edited, or published according to the opensource license

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Search, extract UBX from local code

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new app/feature/bugfix
- [x] Description contains actions to verify app/feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this app/code, uploaded it to the device and verified app/feature/bugfix
