### PR TITLE
Tetris: fix pause restart, stale piece on new game and floating piece locks

### DIFF
--- a/base_pack/tetris_game/CHANGELOG.md
+++ b/base_pack/tetris_game/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 1.6
+
+- Fix pressing OK while paused instantly starting a new game - OK now resumes the game, a new game can only be started from the game-over screen
+- Fix a game restarted from the game-over screen reusing the previous game's falling piece instead of the freshly spawned one, which also broke the 7-bag piece sequence
+- Fix pieces locking mid-air when a move or rotation coincides with a gravity step in the same game tick (floating pieces)
+- Fix rotation kicks near the top of the field reading out of bounds and potentially corrupting memory
+- Fix hard-dropped pieces sometimes stopping one row short and floating in the air
+- Fix rotating a piece near the bottom of the playfield clipping it through the floor
+- Fix a piece continuing to fall after it has landed and lines have been cleared
+- Fix hard drop triggering on the pause and game-over screens
+
+## 1.5
+
+- Add hard drop on Up press
+
+## 1.4
+
+- Update for a newer firmware API (no functional changes)
+
+## 1.3
+
+- Update for a newer firmware API (no functional changes)
+
+## 1.2
+
+- Add 7-bag randomizer for a fair piece distribution
+- Add next piece preview
+- Add pause on Back press (hold Back to quit)
+- Show the cleared lines count during the game
+
+## 1.1
+
+- Fix a possible freeze by moving screen updates outside the game state lock
+
+## 1.0
+
+- Initial release: classic Tetris with clockwise rotation and wall kicks

--- a/base_pack/tetris_game/application.fam
+++ b/base_pack/tetris_game/application.fam
@@ -9,7 +9,7 @@ App(
     fap_icon="tetris_10px.png",
     fap_category="Games",
     fap_author="@xMasterX & @jeffplang & @noiob",
-    fap_version="1.5",
+    fap_version="1.6",
     fap_description="Tetris Game",
     fap_icon_assets="assets"
 )

--- a/base_pack/tetris_game/tetris_game.c
+++ b/base_pack/tetris_game/tetris_game.c
@@ -333,8 +333,8 @@ static void tetris_game_apply_kick(Point points[], Point kick) {
 
 static bool tetris_game_is_valid_pos(TetrisState* tetris_state, Point* shape) {
     for(int i = 0; i < 4; i++) {
-        if(shape[i].y >= FIELD_HEIGHT || shape[i].x < 0 || shape[i].x > (FIELD_WIDTH - 1) ||
-           tetris_state->playField[shape[i].y][shape[i].x] == true) {
+        if(shape[i].y < 0 || shape[i].y >= FIELD_HEIGHT || shape[i].x < 0 ||
+           shape[i].x >= FIELD_WIDTH || tetris_state->playField[shape[i].y][shape[i].x] == true) {
             return false;
         }
     }
@@ -413,7 +413,16 @@ static void
     }
 
     if(wasDownMove) {
-        if(tetris_game_piece_at_bottom(tetris_state, newPiece)) {
+        // Apply gravity to the committed piece, not to the caller's candidate: a
+        // candidate combining a rejected input transform with the down move could
+        // otherwise read as "at bottom", locking the piece mid-air (floating piece)
+        Piece downPiece;
+        memcpy(&downPiece, &tetris_state->currPiece, sizeof(downPiece));
+        for(int i = 0; i < 4; i++) {
+            downPiece.p[i].y += 1;
+        }
+
+        if(tetris_game_piece_at_bottom(tetris_state, &downPiece)) {
             furi_timer_stop(tetris_state->timer);
 
             tetris_state->hardDropping = false;
@@ -459,6 +468,8 @@ static void
                 memcpy(&tetris_state->currPiece, spawnedPiece, sizeof(tetris_state->currPiece));
                 furi_timer_start(tetris_state->timer, tetris_state->fallSpeed);
             }
+        } else {
+            memcpy(&tetris_state->currPiece, &downPiece, sizeof(tetris_state->currPiece));
         }
     }
 
@@ -551,8 +562,16 @@ int32_t tetris_game_app() {
                             tetris_game_remove_curr_piece(tetris_state);
                             tetris_game_try_rotation(tetris_state, newPiece);
                             tetris_game_render_curr_piece(tetris_state);
+                        } else if(tetris_state->gameState == GameStatePaused) {
+                            tetris_state->gameState = GameStatePlaying;
                         } else {
                             tetris_game_init_state(tetris_state);
+                            // Resync the candidate piece, otherwise the previous game's
+                            // leftover piece would overwrite the freshly spawned one
+                            memcpy(
+                                newPiece,
+                                &tetris_state->currPiece,
+                                sizeof(tetris_state->currPiece));
                         }
                         break;
                     case InputKeyBack:
@@ -578,12 +597,6 @@ int32_t tetris_game_app() {
                 }
             } else if(event.type == EventTypeTick) {
                 wasDownMove = true;
-            }
-        }
-
-        if(wasDownMove) {
-            for(int i = 0; i < 4; i++) {
-                newPiece->p[i].y += 1;
             }
         }
 


### PR DESCRIPTION
Fixes the remaining gameplay bugs in the Tetris app and closes out the open Tetris issues.

Closes #37, closes #196.

## What's fixed

**1. OK while paused instantly wiped the game (#37)**
The OK handler's else-branch caught `GameStatePaused` as well as `GameStateGameOver`, so pausing and pressing OK silently started a new game. OK now resumes from pause; a new game starts only from the game-over screen.

**2. New game reused the previous game's falling piece (#37)**
The bag reset itself was fixed back in v1.2 (#25), but the reported symptom survived for another reason: after restarting via OK, the main loop's piece candidate (copied before the event was handled) was stale, and `process_step` committed it over the freshly spawned piece. The "new" game therefore started with the dead game's last piece - which the 7-bag never drew, and which could coincidentally match the next-piece preview. The candidate is now re-synced after init.

**3. Pieces locking mid-air (#196)**
The main loop merged input transforms (move/rotate) and gravity into one combined candidate. When the combined candidate was rejected, `piece_at_bottom` still read it as "at bottom" and locked the unmoved piece - hanging over an air gap. #210 fixed the hard-drop variants; the same race remained reachable by rotating/moving while soft-dropping (both can land in the same 10 ms iteration). Gravity is now applied inside `process_step` to the committed piece, so a lock structurally implies direct support below. This also removes an out-of-bounds `playField` read for wall-shifted candidates in `piece_at_bottom`.

**4. Out-of-bounds read/write on top-of-field rotation kicks** (found during review)
`is_valid_pos` had no negative-y guard, so rotation kicks with negative y offsets near the top of the field could read `playField` out of bounds and, if the garbage read passed, commit a piece at negative y - corrupting memory via the `uint8_t` cast in render/remove. Committed pieces are now always storable in the field.

## Validation

- Built against ufbt SDK (API 87.9) and Unleashed dev via fbt (API 88.0); fbt lint/format clean
- Tested on device (Flipper Zero, Unleashed dev): pause-resume, restart freshness after game over, floating-piece hammering (soft-drop + rotate, moves into walls, air-gap stacks), top-of-field rotation spam near game over, plus regression pass over the #210 fixes (flush hard-drop landing, floor rotation, post-line-clear lock, no drop on pause/game-over screens) and 7-bag distribution

Also bumps the app to 1.6 and adds a `CHANGELOG.md` backfilled from the app's version history (1.0-1.6, including the previously unreleased #210 fixes).

Note on #19: the requested 7-bag randomizer has been implemented since v1.2 (#25) and is confirmed working - the issue can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)