### PR TITLE
Video Poker: flexible bid controls

### DIFF
--- a/apps_source_code/videopoker/CHANGELOG.md
+++ b/apps_source_code/videopoker/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 1.4
+
+- Add Up/Down press to double or halve the bet (replaces Up = all-in; all-in is still reachable by doubling past half the bank or wrapping Left at the minimum)
+- Add Up/Down hold to bet half the bank
+- Make Left/Right +/-$10 steps clamp cleanly when the bet is not a multiple of $10
+- Fix the bet re-entering the betting screen below the table minimum after a low-bank win
+
+## 1.3
+
+- Version bump for catalog compatibility (no functional changes)
+
+## 1.2
+
+- Add all-in on Up press and bet wraparound on Left/Right
+- Fix the game state mutex declaration
+
+## 1.1
+
+- Version bump for catalog compatibility (no functional changes)
+
+## 1.0
+
+- Initial release: Jacks or Better video poker with betting, hold selection and payouts

--- a/apps_source_code/videopoker/application.fam
+++ b/apps_source_code/videopoker/application.fam
@@ -11,6 +11,6 @@ App(
     fap_category="Games",
     fap_author="@PixlEmly",
     fap_weburl="https://github.com/PixlEmly",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_description="Video poker is a casino game based on five-card draw poker",
 )

--- a/apps_source_code/videopoker/poker.c
+++ b/apps_source_code/videopoker/poker.c
@@ -56,9 +56,9 @@ typedef struct {
     int minbet;
 } PokerPlayer;
 
-/* GameState 
+/* GameState
 0=Splash/help, OK button (later on up/down for rules or settings)
-1=cards down, betting enabled, left/right to change bet, OK to confirm
+1=cards down, betting enabled: left/right +/-10, up/down double/halve, hold up/down for half the bank, OK to confirm
 2=first hand, holding enabled, left/right to pick card, OK to hold/unhold card, down to confirm
 3=second hand, only confirm to claim rewards
 4=game over/won 
@@ -373,6 +373,12 @@ static int check_for_dupes(PokerPlayer* app) {
     return 1;
 }
 
+/* Keep the bet between the table minimum and the player's bank (bank wins if it drops below the minimum) */
+static void clamp_bet(PokerPlayer* app) {
+    if(app->bet < app->minbet) app->bet = app->minbet;
+    if(app->bet > app->score) app->bet = app->score;
+}
+
 /* Functions that recognize winning hands */
 
 /*
@@ -585,7 +591,7 @@ void poker_draw_callback(Canvas* canvas, void* ctx) {
     if(poker_player->GameState == 1) {
         snprintf(buffer, sizeof(buffer), "Bet:%d", poker_player->bet);
         canvas_draw_str_aligned(canvas, 0, 0, AlignLeft, AlignTop, buffer);
-        snprintf(buffer, sizeof(buffer), "<*> Place Bet");
+        snprintf(buffer, sizeof(buffer), "<^v*> Place Bet");
         canvas_draw_str_aligned(canvas, 0, 9, AlignLeft, AlignTop, buffer);
 
         for(int i = 0; i < 5; ++i) {
@@ -720,12 +726,6 @@ int32_t video_poker_app(void* p) {
         if(status == FuriStatusOk) {
             if(event.type == InputTypePress) {
                 switch(event.key) {
-                case InputKeyUp:
-                    if(poker_player->GameState == 1) {
-                        poker_player->bet = poker_player->score;
-                    }
-                    Shake();
-                    break;
                 case InputKeyDown:
                     if(poker_player->GameState == 2) {
                         playcard(poker_player);
@@ -738,10 +738,12 @@ int32_t video_poker_app(void* p) {
                     break;
                 case InputKeyLeft:
                     if(poker_player->GameState == 1) {
-                        if(poker_player->bet >= poker_player->minbet + 10) {
+                        if(poker_player->bet - 10 >= poker_player->minbet) {
                             poker_player->bet -= 10;
+                        } else if(poker_player->bet > poker_player->minbet) {
+                            poker_player->bet = poker_player->minbet;
                         } else {
-                            poker_player->bet = poker_player->score;
+                            poker_player->bet = poker_player->score; /* wrap to all-in */
                         }
                     } else if(poker_player->selected > 0 && poker_player->GameState == 2) {
                         poker_player->selected--;
@@ -755,8 +757,9 @@ int32_t video_poker_app(void* p) {
                         if(poker_player->bet < poker_player->score) {
                             poker_player->bet += 10;
                         } else {
-                            poker_player->bet = poker_player->minbet;
+                            poker_player->bet = poker_player->minbet; /* wrap to minimum */
                         }
+                        clamp_bet(poker_player);
                     }
                     if(poker_player->selected < 4 && poker_player->GameState == 2) {
                         poker_player->selected++;
@@ -787,9 +790,7 @@ int32_t video_poker_app(void* p) {
                                 poker_player->bet * paytable[recognize(poker_player)];
                         }
                         poker_player->GameState = 1;
-                        if(poker_player->bet > poker_player->score) {
-                            poker_player->bet = poker_player->score;
-                        }
+                        clamp_bet(poker_player);
                         poker_player->held[0] = 0;
                         poker_player->held[1] = 0;
                         poker_player->held[2] = 0;
@@ -818,6 +819,25 @@ int32_t video_poker_app(void* p) {
                     break;
                 default:
                     break;
+                }
+            } else if(event.type == InputTypeShort && poker_player->GameState == 1) {
+                /* Double or halve the bet */
+                if(event.key == InputKeyUp) {
+                    if(poker_player->bet <= poker_player->score / 2) {
+                        poker_player->bet *= 2;
+                    } else {
+                        poker_player->bet = poker_player->score;
+                    }
+                } else if(event.key == InputKeyDown) {
+                    poker_player->bet /= 2;
+                    clamp_bet(poker_player);
+                }
+            } else if(event.type == InputTypeLong && poker_player->GameState == 1) {
+                /* Bet half the bank */
+                if(event.key == InputKeyUp || event.key == InputKeyDown) {
+                    poker_player->bet = poker_player->score / 2;
+                    clamp_bet(poker_player);
+                    Shake();
                 }
             }
         }


### PR DESCRIPTION
Closes #163

Implements the requested bid strategy controls in the betting phase:

- **Left/Right**: +/-$10 as before, with the existing wraparound (Left below the minimum wraps to all-in, Right at all-in wraps to the minimum)
- **Up/Down press**: double / halve the current bet
- **Up/Down hold**: bet half the bank, with vibro feedback

All examples from the issue behave as specified (bank $1000 bet $10 -> Left -> $1000 -> Down -> $500; bank $3000 bet $500 -> Up -> $1000; bank $10000 -> long Down -> $5000 -> Down -> $2500).

Implementation notes:

- Up/Down betting actions use `InputTypeShort`/`InputTypeLong` (mutually exclusive per press), so they cannot collide with each other or with the `InputTypePress`-based deal action of Down in the hold phase; the stray vibration on Up press in every screen is gone
- Doubling is overflow-safe and caps at all-in, so the old Up = all-in remains reachable by doubling past half the bank
- A `clamp_bet` helper enforces `minbet <= bet <= bank` on every mutation. This also fixes the +$10 step overshooting the bank for bets that halving makes non-multiples of $10, and a state where the betting screen could be re-entered with the bet below the table minimum after winning from a sub-minimum all-in (which would have made "halve" raise the bet)
- Betting hint updated to `<^v*> Place Bet`; CHANGELOG.md added with history backfilled from git; `fap_version` 1.3 -> 1.4

Builds clean under ufbt (API 88.0), `ufbt format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)