### PR TITLE
Video Poker: saturate the payout so a big win cannot overflow the bank

### DIFF
--- a/apps_source_code/videopoker/CHANGELOG.md
+++ b/apps_source_code/videopoker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5
+
+- Fix a winning hand at a very large bet overflowing the bank, which could pay out the wrong amount or end the game on the "You have run out of money!" screen
+- Cap the bank at $1,000,000,000 so the bet controls cannot overflow either
+
 ## 1.4
 
 - Add Up/Down press to double or halve the bet (replaces Up = all-in; all-in is still reachable by doubling past half the bank or wrapping Left at the minimum)

--- a/apps_source_code/videopoker/application.fam
+++ b/apps_source_code/videopoker/application.fam
@@ -11,6 +11,6 @@ App(
     fap_category="Games",
     fap_author="@PixlEmly",
     fap_weburl="https://github.com/PixlEmly",
-    fap_version="1.4",
+    fap_version="1.5",
     fap_description="Video poker is a casino game based on five-card draw poker",
 )

--- a/apps_source_code/videopoker/poker.c
+++ b/apps_source_code/videopoker/poker.c
@@ -23,6 +23,10 @@ Sometimes duplicate cards will show up. there is a function to test this. I shou
 
 #define TAG "Video Poker"
 
+/* Bank ceiling, at roughly half of INT_MAX so the bet arithmetic (+/-10 steps
+and doubling) stays inside int - a larger multiplier would need a lower cap */
+#define MAX_BANK 1000000000
+
 static void Shake(void) {
     NotificationApp* notification = furi_record_open(RECORD_NOTIFICATION);
     notification_message(notification, &sequence_single_vibro);
@@ -785,9 +789,16 @@ int32_t video_poker_app(void* p) {
                                  ->held[poker_player->selected]; //cursed and bad pls replace
                     } else if(poker_player->GameState == 3) {
                         /* accept your fate */
-                        if(recognize(poker_player) != 9) {
-                            poker_player->score +=
-                                poker_player->bet * paytable[recognize(poker_player)];
+                        int hand_rank = recognize(poker_player);
+                        if(hand_rank != 9) {
+                            /* Both the payout and the new bank total overflow int at very
+                            large bets - as reported that corrupted the score and dropped a
+                            winning hand on the game-over screen. Work the total out in 64
+                            bits and saturate: a bank this large is already meaningless, and
+                            widening score would ripple through every %d */
+                            int64_t total = (int64_t)poker_player->score +
+                                            (int64_t)poker_player->bet * paytable[hand_rank];
+                            poker_player->score = total > MAX_BANK ? MAX_BANK : (int)total;
                         }
                         poker_player->GameState = 1;
                         clamp_bet(poker_player);


### PR DESCRIPTION
Closes #239

`score += bet * paytable[]` was computed entirely in `int`, so both the payout and the resulting bank total could overflow. At the bet reported in #239 that corrupted the score, and the `score <= 0` check immediately below then dropped the player on the "You have run out of money!" screen - a jackpot reported as a bankruptcy. Depending on the bet it could instead wrap positive and silently pay out the wrong amount, with no game-over at all.

The new bank total is now worked out in 64 bits and saturated:

```c
int hand_rank = recognize(poker_player);
if(hand_rank != 9) {
    int64_t total = (int64_t)poker_player->score +
                    (int64_t)poker_player->bet * paytable[hand_rank];
    poker_player->score = total > MAX_BANK ? MAX_BANK : (int)total;
}
```

This is the only place the score grows (the other three writes are the two `= 1000` resets and the pledge, which subtracts), so the bank - and `highscore`, which just copies it - can no longer overflow.

### Why MAX_BANK and not INT_MAX

An earlier draft saturated at `INT_MAX`. Review caught that this makes a pre-existing overflow newly reachable: with the bank pinned at exactly `INT_MAX`, hold Up (bet = score/2) then tap Up (the doubling guard passes with equality, bet = `INT_MAX-1`) then press Right, and the `bet += 10` step overflows. Before the fix the bank could never sit at `INT_MAX` - it wrapped negative instead - so that window was unreachable.

Capping at roughly half of `INT_MAX` keeps the whole bet domain away from the type limit rather than requiring a per-site overflow guard, and it composes with the existing invariant: `clamp_bet()` already binds `bet` to `score`, so bounding `score` bounds `bet` for free. It also avoids editing the betting logic that just shipped in 1.4 (#163). Every arithmetic site was enumerated against the new ceiling; the tightest (`bet += 10`) peaks at 1,000,000,009, leaving over `INT_MAX/2` of slack.

The cap is disclosed in the changelog rather than being silent policy, and it only ever bites on the way up - a capped win can never look like a loss.

### Also in this change

- Hoist the doubled `recognize()` call into `hand_rank`. It is idempotent (it only rebuilds its own `shand` scratch buffer from `hand`), so this is behaviour-preserving, and it saves a full selection sort plus up to seven predicate checks per paying hand.
- `fap_version` 1.4 -> 1.5 with a CHANGELOG entry covering both failure symptoms and the new ceiling.

### Verification

Builds clean under ufbt (API 88.0), `ufbt format` applied. Reviewed by the code-review, silent-failure and comment agents plus a four-angle simplify pass; the silent-failure pass fuzzed 20,000 modelled sessions across banks from 1 to `INT_MAX` and saw zero wins ending as game-over, zero negative banks and zero invalid bets.

Two pre-existing issues were found during review and deliberately left out of scope: the draw callback still calls `recognize()` twice per frame, and `playcard()` has an out-of-bounds `hold[5]` stack access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)