### PR TITLE
Nightstand Clock: fix unreachable nightlight, 12h midnight, and notification-record lifetime (closes #243)

### DIFF
--- a/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
+++ b/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.1
+
+- Fix the 12-hour clock showing midnight as `00:xx AM` instead of `12:xx AM`
+- Fix the brightness control so the red LED nightlight stays reachable from every starting brightness: round the inherited system brightness to the nearest step and clamp brightness to 0-100 (previously levels such as 35/45/65/70/90/95% started off-grid, so Down skipped 0 and the nightlight could never be switched on)
+- Restore the notification settings before releasing the notification record when exiting
+
+## 1.0
+
+- Initial release: overnight clock with screen-brightness control, red LED nightlight, and a stopwatch

--- a/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
+++ b/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix the 12-hour clock showing midnight as `00:xx AM` instead of `12:xx AM`
 - Fix the brightness control so the red LED nightlight stays reachable from every starting brightness: round the inherited system brightness to the nearest step and clamp brightness to 0-100 (previously levels such as 35/45/65/70/90/95% started off-grid, so Down skipped 0 and the nightlight could never be switched on)
 - Restore the notification settings before releasing the notification record when exiting
+- Free the view_port and notification record (and restore the display settings) if the periodic timer fails to allocate on startup
 
 ## 1.0
 

--- a/non_catalog_apps/FlipperNightStand_clock/application.fam
+++ b/non_catalog_apps/FlipperNightStand_clock/application.fam
@@ -9,6 +9,6 @@ App(
     fap_category="Tools",
     fap_author="@nymda & @Willy-JL",
     fap_weburl="https://github.com/nymda/FlipperNightStand",
-    fap_version="1.0",
+    fap_version="1.1",
     fap_description="Clock with screen brightness controls",
 )

--- a/non_catalog_apps/FlipperNightStand_clock/clock_app.c
+++ b/non_catalog_apps/FlipperNightStand_clock/clock_app.c
@@ -324,6 +324,12 @@ int32_t clock_app(void* p) {
 
     if(timer == NULL) {
         FURI_LOG_E(TAG, "Cannot create timer");
+        //restore the notification settings mutated above before bailing out
+        notif->settings.display_off_delay_ms = Saved_display_off_delay_ms;
+        notification_message(notif, &sequence_display_backlight_enforce_auto);
+        notification_message(notif, &led_reset);
+        furi_record_close(RECORD_NOTIFICATION);
+        view_port_free(view_port);
         furi_mutex_free(plugin_state->mutex);
         furi_message_queue_free(plugin_state->event_queue);
         free(plugin_state);

--- a/non_catalog_apps/FlipperNightStand_clock/clock_app.c
+++ b/non_catalog_apps/FlipperNightStand_clock/clock_app.c
@@ -60,6 +60,7 @@ void handle_up() {
         led = false;
         notification_message(notif, &led_off);
         brightness += 5;
+        if(brightness > 100) brightness = 100;
     }
     set_backlight_brightness((float)(brightness / 100.f));
 }
@@ -68,6 +69,7 @@ void handle_down() {
     dspBrightnessBarFrames = dspBrightnessBarDisplayFrames;
     if(brightness > 0) {
         brightness -= 5;
+        if(brightness < 0) brightness = 0;
         if(brightness == 0) { //trigger only on the first brightness 5 -> 0 transition
             led = true;
             notification_message(notif, &led_on);
@@ -150,15 +152,10 @@ static void clock_render_callback(Canvas* const canvas, void* ctx) {
         snprintf(
             time_string, TIME_LEN, CLOCK_TIME_FORMAT, curr_dt.hour, curr_dt.minute, curr_dt.second);
     } else {
-        bool pm = curr_dt.hour > 12;
         bool pm12 = curr_dt.hour >= 12;
-        snprintf(
-            time_string,
-            TIME_LEN,
-            CLOCK_TIME_FORMAT,
-            pm ? curr_dt.hour - 12 : curr_dt.hour,
-            curr_dt.minute,
-            curr_dt.second);
+        uint8_t hour12 = curr_dt.hour % 12;
+        if(hour12 == 0) hour12 = 12;
+        snprintf(time_string, TIME_LEN, CLOCK_TIME_FORMAT, hour12, curr_dt.minute, curr_dt.second);
 
         snprintf(
             meridian_string,
@@ -309,7 +306,7 @@ int32_t clock_app(void* p) {
     notif = furi_record_open(RECORD_NOTIFICATION);
 
     float SavedBrightness = notif->settings.display_brightness;
-    brightness = SavedBrightness * 100; // Keep current brightness by default
+    brightness = (int)roundf(SavedBrightness * 100.f); // Keep current brightness by default
 
     uint32_t Saved_display_off_delay_ms = notif->settings.display_off_delay_ms;
     notif->settings.display_off_delay_ms = 0;
@@ -387,7 +384,6 @@ int32_t clock_app(void* p) {
     view_port_enabled_set(view_port, false);
     gui_remove_view_port(gui, view_port);
     furi_record_close(RECORD_GUI);
-    furi_record_close(RECORD_NOTIFICATION);
     view_port_free(view_port);
     furi_message_queue_free(plugin_state->event_queue);
     furi_mutex_free(plugin_state->mutex);
@@ -399,6 +395,8 @@ int32_t clock_app(void* p) {
     notification_message(notif, &sequence_display_backlight_enforce_auto);
     set_backlight_brightness(SavedBrightness);
     notification_message(notif, &led_reset);
+
+    furi_record_close(RECORD_NOTIFICATION);
 
     return 0;
 }


### PR DESCRIPTION
Fixes #243.

Three user-facing bugs in the Nightstand Clock app (`non_catalog_apps/FlipperNightStand_clock`), plus a startup resource leak found during review.

### 1. LED nightlight unreachable at some brightness levels

The internal brightness counter was seeded with a truncating `SavedBrightness * 100`, and `handle_up`/`handle_down` stepped by +/-5 with no clamp. The system LCD brightness uses 0.05 steps, six of which truncate off the multiple-of-5 grid (35/45/65/70/90/95% -> 34/44/64/69/89/94), so Down walked `...,9,4,-1` and never hit 0 - the nightlight (`brightness == 0`) could never be switched on, and brightness left the 0-100 range.

Fix: `roundf` on init + clamp to `[0,100]` in both handlers. This also removes a latent progress-bar assert-crash in debug builds.

### 2. 12-hour clock shows midnight as `00`

Hour 0 printed as `00:xx AM` instead of `12:xx AM`. Fixed with `hour12 = hour % 12; if(hour12 == 0) hour12 = 12;` (noon/PM unchanged).

### 3. `notif` used after `furi_record_close`

On exit the settings-restore ran after the notification record had already been closed. Moved the close to after the restore block.

### 4. Startup timer-alloc failure leaked the notification record + view_port

The `timer == NULL` early-return freed only the mutex/queue/state, leaking the open `RECORD_NOTIFICATION` handle and the allocated `view_port` and leaving the backlight forced on. It now restores the notification settings and releases both, mirroring the normal teardown.

---

`fap_version` 1.0 -> 1.1, added `CHANGELOG.md`. This app is third-party (`@nymda & @Willy-JL`); the fixes may want mirroring upstream.

Reviewed with the pr-review-toolkit code-reviewer and code-simplifier agents and clang-formatted with the project style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
