### PR TITLE
Nightstand Clock: make Up/Down actually change the screen brightness (closes #245)

### DIFF
--- a/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
+++ b/non_catalog_apps/FlipperNightStand_clock/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2
+
+- Fix Up/Down not actually changing the screen brightness: the new level is now pushed to the panel even while the backlight is held always-on (previously the on-screen bar moved but the backlight stayed at the startup brightness)
+
 ## 1.1
 
 - Fix the 12-hour clock showing midnight as `00:xx AM` instead of `12:xx AM`

--- a/non_catalog_apps/FlipperNightStand_clock/application.fam
+++ b/non_catalog_apps/FlipperNightStand_clock/application.fam
@@ -9,6 +9,6 @@ App(
     fap_category="Tools",
     fap_author="@nymda & @Willy-JL",
     fap_weburl="https://github.com/nymda/FlipperNightStand",
-    fap_version="1.1",
+    fap_version="1.2",
     fap_description="Clock with screen brightness controls",
 )

--- a/non_catalog_apps/FlipperNightStand_clock/clock_app.c
+++ b/non_catalog_apps/FlipperNightStand_clock/clock_app.c
@@ -49,9 +49,25 @@ static const NotificationSequence led_reset = {
     NULL,
 };
 
+// Use force_on (not backlight_on) so the level is pushed to the panel even when
+// the backlight is already on - a plain backlight_on early-returns in that case.
+// Used on exit to restore the saved brightness after the enforce lock is freed.
 void set_backlight_brightness(float brightness) {
     notif->settings.display_brightness = brightness;
-    notification_message(notif, &sequence_display_backlight_on);
+    notification_message(notif, &sequence_display_backlight_force_on);
+}
+
+// While the app holds the backlight on with enforce_on, a plain backlight_on
+// does not change the screen: the notification service early-returns when the
+// backlight is already on, and the enforced "internal" layer that is actually
+// shown is only set once at startup. force_on bypasses that early-return to
+// update the panel now; the enforce pair then refreshes the locked internal
+// layer so the new level cannot be reverted.
+void set_enforced_brightness(float brightness) {
+    notif->settings.display_brightness = brightness;
+    notification_message(notif, &sequence_display_backlight_force_on);
+    notification_message(notif, &sequence_display_backlight_enforce_auto);
+    notification_message(notif, &sequence_display_backlight_enforce_on);
 }
 
 void handle_up() {
@@ -62,7 +78,7 @@ void handle_up() {
         brightness += 5;
         if(brightness > 100) brightness = 100;
     }
-    set_backlight_brightness((float)(brightness / 100.f));
+    set_enforced_brightness((float)(brightness / 100.f));
 }
 
 void handle_down() {
@@ -82,7 +98,7 @@ void handle_down() {
             notification_message(notif, &led_off);
         }
     }
-    set_backlight_brightness((float)(brightness / 100.f));
+    set_enforced_brightness((float)(brightness / 100.f));
 }
 
 static void clock_input_callback(InputEvent* input_event, void* ctx) {
@@ -121,9 +137,6 @@ void elements_progress_bar_vertical(
 static void clock_render_callback(Canvas* const canvas, void* ctx) {
     //canvas_clear(canvas);
     //canvas_set_color(canvas, ColorBlack);
-
-    //avoids a bug with the brightness being reverted after the backlight-off period
-    //set_backlight_brightness((float)(brightness / 100.f));
 
     if(dspBrightnessBarFrames > 0) {
         elements_progress_bar_vertical(canvas, 119, 1, 62, (float)(brightness / 100.f));


### PR DESCRIPTION
Fixes #245.

Pressing Up/Down in Nightstand Clock moved the on-screen brightness bar but did not change the actual screen backlight - it stayed at the brightness the app started with. Confirmed on-device (Unleashed, API 88.0), and now confirmed fixed on-device.

### Root cause

The app pins the backlight on with `sequence_display_backlight_enforce_on` and sets `display_off_delay_ms = 0`. On Unleashed, `notification_apply_notification_led_layer` early-returns without touching the hardware when the backlight is already on (`(light == LightBacklight) & lcd_backlight_is_on`), and with the auto-off delay forced to 0 that flag never clears. So `set_backlight_brightness()`'s plain `sequence_display_backlight_on` updated the setting and the transient layer but never pushed the new level to the panel.

### Fix

Use `sequence_display_backlight_force_on`, whose handler clears `lcd_backlight_is_on` before applying, so the new brightness reaches the panel.

- `set_enforced_brightness()` (Up/Down): `force_on` -> `enforce_auto` -> `enforce_on`. The leading `force_on` moves the display to the notification layer and updates the panel; the enforce pair then refreshes the locked "internal" layer at the new level (suppressed from the panel because the index is now the notification layer, so no flicker) and keeps the enforce lock balanced.
- `set_backlight_brightness()` (exit restore): also switched to `force_on` so the saved brightness is reapplied immediately after the enforce lock is released.
- Removed the author's obsolete commented-out per-frame re-apply workaround.

### Firmware dependency

`sequence_display_backlight_force_on` exists in Unleashed/RM-family firmware (and the ufbt SDK this repo builds against) but **not** in stock OFW, where it would fail to link. This is consistent with all-the-plugins targeting Unleashed.

`fap_version` 1.1 -> 1.2, CHANGELOG updated. Pre-existing and independent of #243 / #244; surfaced during on-device testing of that work. Third-party app (`@nymda & @Willy-JL`), so the fix may want mirroring upstream.

Reviewed with the code-reviewer and code-simplifier agents (traced against the Unleashed notification-service source); on-device confirmed (brightness changes and holds, exit restores). clang-formatted with the project style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
