### PR TITLE
Add lock-threads workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,50 @@
+# Lock closed issues and PRs after a period of inactivity, so stale threads
+# don't accumulate "me too" / necro comments that never reach a maintainer.
+# Locking is not closing: it only stops new comments, and anyone can still open
+# a fresh issue from the templates. The bot never auto-closes anything.
+#
+# Runs once a day (dessant recommends daily to keep resource use low) and can be
+# kicked off by hand via workflow_dispatch. Each thread type only gets processed
+# when its *-inactive-days is set, so issues and PRs are opted in explicitly below.
+
+name: Lock threads
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily, 03:00 UTC (off-peak)
+  workflow_dispatch:
+
+# Locking edits issue/PR state; no code is checked out or executed. Everything
+# unlisted is denied.
+permissions:
+  issues: write
+  pull-requests: write
+
+# One sweep at a time; a manual run and the nightly cron shouldn't overlap.
+concurrency:
+  group: lock-threads
+  cancel-in-progress: false
+
+jobs:
+  lock:
+    name: Lock inactive closed threads
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v6
+        with:
+          issue-inactive-days: "14"
+          pr-inactive-days: "14"
+          # This tracker is per-app, so point people at naming the app rather
+          # than at the firmware version (see .github/ISSUE_TEMPLATE).
+          issue-comment: >
+            This issue has been automatically locked since there has been no
+            activity for a while after it was closed. If you're hitting the same
+            problem, please open a new issue naming the app it affects and how
+            to reproduce it.
+          pr-comment: >
+            This pull request has been automatically locked since there has been
+            no activity for a while after it was closed. If you'd like to pick
+            this up, please open a new pull request for the app.
+          # Default reason "resolved" fits closed-then-idle threads.
+          issue-lock-reason: resolved
+          pr-lock-reason: resolved


### PR DESCRIPTION
Mirrors the `Lock threads` workflow from the Unleashed firmware repo.

Closed issues and PRs get locked after 14 days of inactivity, so stale threads stop accumulating "me too" / necro comments that never reach a maintainer. Locking is not closing - it only stops new comments, nothing is auto-closed, and anyone can still open a fresh issue from the templates.

- Runs daily at 03:00 UTC, plus `workflow_dispatch` for manual sweeps
- `issues: write` / `pull-requests: write` only; no checkout, no code execution
- `concurrency` group so a manual run and the nightly cron cannot overlap
- Lock reason `resolved` on both issues and PRs
- `dessant/lock-threads@v6` (current major, latest release v6.0.2)

The only difference from the Unleashed copy is the comment wording: this tracker is per-app, so it asks people to name the affected app instead of pointing at a firmware version.

The existing backlog (169 closed issues + 69 closed/merged PRs) has already been locked with reason `resolved` and no comment, so this workflow's first run has nothing to back-fill and will not comment on any old thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
