### PR TITLE
Tighten issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -14,6 +14,17 @@ body:
       description: Which app is affected? (name as it appears in the app menu)
     validations:
       required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: >
+        The app's own version, not the firmware version. Read `fap_version` from
+        the app's `application.fam` - in its folder in this repo, or in the app's
+        folder on your microSD.
+      placeholder: e.g. 1.4
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
@@ -30,13 +41,25 @@ body:
         1. Open the app...
         2. Press '...'
         3. See the issue
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
       label: Firmware version
       description: Which Unleashed firmware version are you running?
   - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste any logs or other text output here.
+      # Rendered as a code block so logs arrive intact instead of being reflowed
+      # as Markdown. This is the only field with `render`: it also disables file
+      # attachments, which is a fair trade for logs but not for anything else -
+      # hence the separate catch-all below, where photos of the screen can go.
+      render: Text
+  - type: textarea
     id: anything-else
     attributes:
       label: Anything else?
-      description: Logs, photos, or anything else that helps.
+      description: Screenshots, photos of the Flipper screen, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/02_new_app.yml
+++ b/.github/ISSUE_TEMPLATE/02_new_app.yml
@@ -6,6 +6,10 @@ body:
     attributes:
       value: |
         Use this to request a new app be added to the pack.
+
+        The pack is redistributed under GPLv3, so an app can only be included if its
+        license allows that. Please check the source repo before opening the request -
+        it is the most common reason one can't be accepted.
   - type: input
     id: app
     attributes:
@@ -17,6 +21,24 @@ body:
     attributes:
       label: Source / repository link
       description: Link to the app's source code.
+    validations:
+      required: true
+  - type: dropdown
+    id: license
+    attributes:
+      label: License
+      description: >
+        What license is the app's source published under? Pick "No license file" if
+        the repo has none - that means it is not redistributable by default, however
+        permissive it looks.
+      options:
+        - GPL-3.0
+        - GPL-2.0
+        - MIT
+        - Apache-2.0
+        - BSD (2- or 3-clause)
+        - Other (please say which below)
+        - No license file / unclear
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,14 @@
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My code is released under GPLv3 license and can be edited, or published according to the opensource license
+- [ ] I have bumped `fap_version` in the app's `application.fam`
+- [ ] I have added an entry to the app's `CHANGELOG.md` describing the change
 
 # AI usage disclosure (Fill this out):
 
+Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".
+
+- [ ] No AI assistance.
 - [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
 - [ ] Fully AI generated (explain what all the generated code does in moderate detail).
 


### PR DESCRIPTION
Follow-up to the workflow review. All four requested changes, plus the license gap.

## Bug report

- **Reproduction is now required.** It was optional, and a report without repro steps is rarely actionable.
- **New required "App version" field**, for the app's own `fap_version` from `application.fam`. The firmware version alone does not say which build of an app broke.
- **Split the old catch-all in two.** A `Logs` box with `render: Text` so pasted output arrives intact, and a plain `Anything else?` box that still takes file attachments.

  On `render`: GitHub's spec says a rendered textarea "will not expand for file attachments or Markdown editing". Applying it to every textarea would have left nowhere on the form to attach a photo of the Flipper screen, which for a device app tracker is usually the most useful evidence. Scoping it to the logs field only - the same split Unleashed uses - keeps the mangling fix without that cost.

## New app

- **License is now a required dropdown**, with `No license file / unclear` as an explicit option. The pack ships under GPLv3, so license compatibility decides whether a request can be accepted at all, and the form never asked. The intro text now says so up front.

## Pull request template

- **Added `No AI assistance`** to the disclosure section. With only the two AI options, a hand-written PR left all boxes blank - indistinguishable from ignoring the section.
- **Added checklist items** for bumping `fap_version` and adding a `CHANGELOG.md` entry. That is the convention for app changes, but it was written down nowhere a contributor would encounter it. Worth knowing only 22 of 321 apps currently have a `CHANGELOG.md`, so the template is the main lever for spreading it.

## Verification

All templates parsed and schema-checked: valid element types, no duplicate ids, `required` only on elements that support it, dropdown has options. Every label referenced (`type/bug`, `type/new-app`, `type/enhancement`) exists in the repo, so nothing is silently dropped.

Two things I left alone since they were not in scope - say the word and I will add them: `Firmware version` is still optional free text (Unleashed uses a required dropdown kept current by a release workflow), and `What does it do?` on the new-app form is still optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
